### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -23,9 +23,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: packages/rails-vite-plugin/package-lock.json
-      - run: npm ci
+      - run: npm install
       - run: npm run typecheck
       - run: npm test
       - run: npx eslint src/


### PR DESCRIPTION
This PR replaces `npm ci` with `npm install` and removes the npm cache setup in `.github/workflows/npm.yml`.