### PR TITLE
Simplify vite_rails migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Support custom HTML attributes in `vite_tags` (e.g., `data-turbo-track`, `media`) ([@skryukov])
+- Add `vite_javascript_tag`, `vite_stylesheet_tag`, and `vite_typescript_tag` compat helpers for easier migration from vite_rails ([@skryukov])
+- Auto-discover entrypoints from `sourceDir/entrypoints/` directory ([@skryukov])
+- Support extensionless entry names in `vite_tags` (e.g., `vite_tags("application")`) ([@skryukov])
+
+### Fixed
+
+- `refresh: false` option now correctly disables file watching ([@skryukov])
+
 ## [0.1.0] - 2026-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # RailsVite
 
+[![Gem Version](https://badge.fury.io/rb/rails_vite.svg)](https://rubygems.org/gems/rails_vite)
+
 Vite integration for Rails, inspired by [Laravel's Vite plugin](https://laravel.com/docs/12.x/vite). No proxy, no config duplication, no magic.
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Usage](#usage)
+- [Vite Config](#vite-config)
+- [Adding Frameworks](#adding-frameworks)
+- [SSR](#ssr)
+- [Auto Build](#auto-build)
+- [Testing the Build](#testing-the-build)
+- [Custom Paths](#custom-paths)
+- [Rake Tasks](#rake-tasks)
+- [Migrating from vite_rails](#migrating-from-vite_rails)
+- [Contributing](#contributing)
+- [License](#license)
+
+<a href="https://evilmartians.com/?utm_source=rails_vite&utm_campaign=project_page">
+<img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Built by Evil Martians" width="236" height="54">
+</a>
 
 ## How It Works
 
@@ -62,9 +84,19 @@ Short names are automatically prefixed with `sourceDir` (default: `app/javascrip
 
 | Helper | Purpose |
 |--------|---------|
-| `vite_tags(*entries, nonce: nil)` | Emits script, stylesheet, and modulepreload tags |
+| `vite_tags(*entries, **options)` | Emits script, stylesheet, and modulepreload tags |
+| `vite_javascript_tag(*entries, **options)` | Same as `vite_tags`, appends `.js` to extensionless names |
+| `vite_stylesheet_tag(*entries, **options)` | Same as `vite_tags`, appends `.css` to extensionless names |
+| `vite_typescript_tag(*entries, **options)` | Same as `vite_tags`, appends `.ts` to extensionless names |
 | `vite_asset_path(name)` | Returns the fingerprinted path from the manifest |
 | `vite_image_tag(name, **options)` | Image tag with manifest-resolved src |
+
+All tag helpers accept arbitrary HTML attributes:
+
+```erb
+<%= vite_tags "application.js", "application.css",
+    "data-turbo-track": "reload", nonce: content_security_policy_nonce %>
+```
 
 ### CSS Entry Points
 
@@ -114,7 +146,7 @@ export default defineConfig({
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `input` | auto-detected | Entry point(s). Auto-detects `application.{js,ts,jsx,tsx}` in `sourceDir` |
+| `input` | auto-detected | Entry point(s). If `sourceDir/entrypoints/` exists, all files in it are used. Otherwise, detects `application.{js,ts,jsx,tsx}` in `sourceDir` |
 | `sourceDir` | `'app/javascript'` | Source directory. Short names are prefixed with this. Also sets the `@` import alias |
 | `ssr` | — | SSR entry point |
 | `ssrOutputDirectory` | `'ssr'` | SSR output directory |
@@ -261,6 +293,50 @@ Defaults match the plugin defaults — no config needed if you follow convention
 
 `vite:build` hooks into `assets:precompile` and `test:prepare` automatically. Skip with `SKIP_VITE_BUILD=1`.
 
+
+## Migrating from vite_rails
+
+### 1. Swap dependencies
+
+```ruby
+# Gemfile
+- gem "vite_rails"
++ gem "rails_vite"
+```
+
+```json
+// package.json — replace vite-plugin-ruby with rails-vite-plugin
+- "vite-plugin-ruby": "^5.1.1"
++ "rails-vite-plugin": "^0.1.0"
+```
+
+### 2. Replace `vite.config.ts`
+
+```typescript
+import { defineConfig } from 'vite';
+import rails from 'rails-vite-plugin';
+
+export default defineConfig({
+  plugins: [
+    rails({
+      sourceDir: 'app/frontend',
+    }),
+  ],
+});
+```
+
+If you have an `entrypoints/` directory inside `sourceDir`, all files in it are auto-discovered — no need to list them. Otherwise, set `input` explicitly.
+
+### 3. Delete files
+
+- `config/vite.json` — settings now live in `vite.config.ts`
+- `bin/vite` — no longer needed, `Procfile.dev` runs `npx vite` directly
+
+### 4. Update layouts
+
+Remove `vite_client_tag` and `vite_react_refresh_tag` — both are automatic now.
+
+The `vite_javascript_tag`, `vite_stylesheet_tag`, and `vite_typescript_tag` helpers work as drop-in replacements:
 
 ## Contributing
 

--- a/lib/rails_vite/manifest.rb
+++ b/lib/rails_vite/manifest.rb
@@ -6,9 +6,13 @@ module RailsVite
       @path = path
     end
 
+    # Vite's default resolve.extensions order, plus CSS extensions
+    RESOLVE_EXTENSIONS = %w[.mjs .js .mts .ts .jsx .tsx .json .css .scss .sass .less .styl .pcss].freeze
+
     def lookup(name)
       manifest = data
-      entry = manifest[name] || raise(MissingEntryError.new(name, @path))
+      entry = manifest[name] || resolve_with_extension(name, manifest) ||
+        raise(MissingEntryError.new(name, @path))
 
       {
         file: entry["file"],
@@ -41,6 +45,16 @@ module RailsVite
       JSON.parse(File.read(@path))
     rescue Errno::ENOENT
       raise MissingManifestError.new(@path)
+    end
+
+    def resolve_with_extension(name, manifest)
+      return if File.extname(name).present?
+
+      RESOLVE_EXTENSIONS.each do |ext|
+        entry = manifest["#{name}#{ext}"]
+        return entry if entry
+      end
+      nil
     end
 
     def resolve_imports(entry, seen, manifest)

--- a/lib/rails_vite/tag_helper.rb
+++ b/lib/rails_vite/tag_helper.rb
@@ -7,10 +7,23 @@ module RailsVite
       resolved = entries.map { |e| resolve_vite_entry(e, config.source_dir) }
 
       if config.dev_server_running?
-        vite_dev_tags(resolved, config.dev_server_url, nonce: nonce)
+        vite_dev_tags(resolved, config.dev_server_url, nonce: nonce, **options)
       else
-        vite_prod_tags(resolved, nonce: nonce)
+        vite_prod_tags(resolved, nonce: nonce, **options)
       end
+    end
+    alias_method :vite_tag, :vite_tags
+
+    def vite_javascript_tag(*entries, **options)
+      vite_tags(*entries.map { |e| with_default_ext(e, ".js") }, **options)
+    end
+
+    def vite_stylesheet_tag(*entries, **options)
+      vite_tags(*entries.map { |e| with_default_ext(e, ".css") }, **options)
+    end
+
+    def vite_typescript_tag(*entries, **options)
+      vite_tags(*entries.map { |e| with_default_ext(e, ".ts") }, **options)
     end
 
     def vite_asset_path(name)
@@ -23,7 +36,7 @@ module RailsVite
 
     private
 
-    def vite_dev_tags(entries, dev_url, nonce: nil)
+    def vite_dev_tags(entries, dev_url, nonce: nil, **options)
       tags = []
 
       unless @_vite_client_emitted
@@ -42,13 +55,13 @@ module RailsVite
       end
 
       entries.each do |entry|
-        tags << build_asset_tag(entry, "#{dev_url}/#{entry}", nonce: nonce)
+        tags << build_asset_tag(entry, "#{dev_url}/#{entry}", nonce: nonce, **options)
       end
 
       safe_join(tags, "\n")
     end
 
-    def vite_prod_tags(entries, nonce: nil)
+    def vite_prod_tags(entries, nonce: nil, **options)
       tags = []
       preloaded = Set.new
 
@@ -61,22 +74,26 @@ module RailsVite
           tags << tag.link(rel: "modulepreload", href: vite_asset_url(import_file), nonce: nonce)
         end
 
-        tags << build_asset_tag(entry, vite_asset_url(result[:file]), nonce: nonce)
+        tags << build_asset_tag(entry, vite_asset_url(result[:file]), nonce: nonce, **options)
 
         Array(result[:css]).each do |css_file|
-          tags << tag.link(rel: "stylesheet", href: vite_asset_url(css_file), nonce: nonce)
+          tags << tag.link(rel: "stylesheet", href: vite_asset_url(css_file), nonce: nonce, **options)
         end
       end
 
       safe_join(tags, "\n")
     end
 
-    def build_asset_tag(entry, url, nonce: nil)
+    def build_asset_tag(entry, url, nonce: nil, **options)
       if css_entry?(entry)
-        tag.link(rel: "stylesheet", href: url, nonce: nonce)
+        tag.link(rel: "stylesheet", href: url, nonce: nonce, **options)
       else
-        tag.script(src: url, type: "module", nonce: nonce)
+        tag.script(src: url, type: "module", nonce: nonce, **options)
       end
+    end
+
+    def with_default_ext(name, ext)
+      File.extname(name).empty? ? "#{name}#{ext}" : name
     end
 
     def resolve_vite_entry(entry, source_dir)

--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -194,16 +194,35 @@ function prefixWithSourceDir(entry: string, sourceDir: string): string {
   return `${sourceDir}/${entry}`
 }
 
-const defaultEntryExtensions = ['.js', '.ts', '.jsx', '.tsx']
+const entrypointExtensions = /\.(mjs|js|mts|ts|jsx|tsx|css|scss|sass|less|styl|pcss)$/
 
-function detectEntrypoint(sourceDir: string): string {
-  for (const ext of defaultEntryExtensions) {
+function detectEntrypoint(sourceDir: string): string | string[] {
+  const entrypointsDir = path.join(sourceDir, 'entrypoints')
+  if (fs.existsSync(entrypointsDir)) {
+    return discoverEntrypoints(entrypointsDir).map(
+      (entry) => `entrypoints/${entry}`
+    )
+  }
+
+  for (const ext of ['.js', '.mjs', '.ts', '.mts', '.jsx', '.tsx']) {
     const candidate = path.join(sourceDir, `application${ext}`)
     if (fs.existsSync(candidate)) {
       return `application${ext}`
     }
   }
   return 'application.js'
+}
+
+function discoverEntrypoints(dir: string, base: string = dir): string[] {
+  const entries: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      entries.push(...discoverEntrypoints(path.join(dir, entry.name), base))
+    } else if (entrypointExtensions.test(entry.name)) {
+      entries.push(path.relative(base, path.join(dir, entry.name)))
+    }
+  }
+  return entries
 }
 
 function resolveRefreshPaths(

--- a/packages/rails-vite-plugin/tests/index.test.ts
+++ b/packages/rails-vite-plugin/tests/index.test.ts
@@ -21,7 +21,25 @@ vi.mock('fs', async () => {
         if (filePath.endsWith('app/javascript/application.js')) return true
         // Mock: app/frontend/application.ts exists
         if (filePath.endsWith('app/frontend/application.ts')) return true
+        // Mock: app/assets/entrypoints directory exists
+        if (filePath.endsWith('app/assets/entrypoints')) return true
         return actual.existsSync(filePath)
+      },
+      readdirSync: (dir: string, options?: { withFileTypes: boolean }) => {
+        if (dir.endsWith('app/assets/entrypoints') && options?.withFileTypes) {
+          return [
+            { name: 'application.ts', isDirectory: () => false },
+            { name: 'application.css', isDirectory: () => false },
+            { name: 'README.md', isDirectory: () => false },
+            { name: 'admin', isDirectory: () => true },
+          ]
+        }
+        if (dir.endsWith('app/assets/entrypoints/admin') && options?.withFileTypes) {
+          return [
+            { name: 'index.tsx', isDirectory: () => false },
+          ]
+        }
+        return actual.readdirSync(dir, options as Parameters<typeof actual.readdirSync>[1])
       },
     },
   }
@@ -92,6 +110,32 @@ describe('rails-vite-plugin', () => {
       app: 'app/javascript/application.js',
       admin: 'app/javascript/admin/index.js',
     })
+  })
+
+  it('auto-discovers entrypoints directory', () => {
+    const plugin = rails({ sourceDir: 'app/assets' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toEqual([
+      'app/assets/entrypoints/application.ts',
+      'app/assets/entrypoints/application.css',
+      'app/assets/entrypoints/admin/index.tsx',
+    ])
+  })
+
+  it('filters non-entrypoint files from discovery', () => {
+    const plugin = rails({ sourceDir: 'app/assets' })
+
+    const config = getConfig(plugin)
+    const input = config!.build!.rollupOptions!.input as string[]
+    expect(input).not.toContainEqual(expect.stringContaining('README.md'))
+  })
+
+  it('explicit input takes precedence over entrypoints directory', () => {
+    const plugin = rails({ sourceDir: 'app/assets', input: 'custom.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/assets/custom.js')
   })
 
   // --- Build config defaults ---

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -64,6 +64,24 @@ class ManifestTest < Minitest::Test
     assert_equal "assets/logo-aabbccdd.png", path
   end
 
+  def test_lookup_resolves_extensionless_js
+    result = @manifest.lookup("app/javascript/application")
+
+    assert_equal "assets/application-a1b2c3d4.js", result[:file]
+  end
+
+  def test_lookup_resolves_extensionless_css
+    result = @manifest.lookup("app/javascript/admin")
+
+    assert_equal "assets/admin-deadbeef.css", result[:file]
+  end
+
+  def test_lookup_skips_extension_resolution_when_extension_present
+    assert_raises(RailsVite::MissingEntryError) do
+      @manifest.lookup("app/javascript/application.tsx")
+    end
+  end
+
   def test_missing_entry_raises
     error = assert_raises(RailsVite::MissingEntryError) do
       @manifest.lookup("nonexistent.js")

--- a/test/tag_helper_test.rb
+++ b/test/tag_helper_test.rb
@@ -150,6 +150,13 @@ class TagHelperTest < Minitest::Test
     assert_match %r{rel="stylesheet".*href="/vite/assets/application-x9y8z7w6.css"}, html
   end
 
+  def test_vite_tags_extensionless_production
+    html = vite_tags("application")
+
+    assert_match %r{src="/vite/assets/application-a1b2c3d4.js"}, html
+    assert_match %r{rel="stylesheet".*href="/vite/assets/application-x9y8z7w6.css"}, html
+  end
+
   def test_vite_tags_short_name_dev_mode
     File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript"}')
 
@@ -299,6 +306,30 @@ class TagHelperTest < Minitest::Test
 
     vendor_preloads = html.scan(%r{rel="modulepreload".*?href="/vite/assets/vendor-b3c4d5e6.js"})
     assert_equal 1, vendor_preloads.size, "Shared import should only be preloaded once"
+  end
+
+  # Custom HTML attributes tests
+
+  def test_vite_tags_production_with_custom_attributes
+    html = vite_tags("app/javascript/application.js", "data-turbo-track": "reload")
+
+    assert_match %r{<script.*data-turbo-track="reload"}, html
+    assert_match %r{rel="stylesheet".*data-turbo-track="reload"}, html
+  end
+
+  def test_vite_tags_css_entry_with_custom_attributes
+    html = vite_tags("app/javascript/admin.css", media: "all", "data-turbo-track": "reload")
+
+    assert_match %r{media="all"}, html
+    assert_match %r{data-turbo-track="reload"}, html
+  end
+
+  def test_vite_tags_dev_mode_with_custom_attributes
+    File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript"}')
+
+    html = vite_tags("app/javascript/application.js", "data-turbo-track": "reload")
+
+    assert_match %r{src="http://localhost:5173/app/javascript/application.js".*data-turbo-track="reload"}, html
   end
 
   # Error tests


### PR DESCRIPTION
This PR adds compatibility features for easier migration from `vite_rails`: compat tag helpers (`vite_javascript_tag`, `vite_stylesheet_tag`, `vite_typescript_tag`), custom HTML attributes support, `entrypoints/` directory auto-discovery, and extensionless entry name resolution. It also fixes the `refresh: false` option and adds a migration guide to the README.