### PR TITLE
Add SRI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning].
 - Add `vite_javascript_tag`, `vite_stylesheet_tag`, and `vite_typescript_tag` compat helpers for easier migration from vite_rails ([@skryukov])
 - Auto-discover entrypoints from `sourceDir/entrypoints/` directory ([@skryukov])
 - Support extensionless entry names in `vite_tags` (e.g., `vite_tags("application")`) ([@skryukov])
+- Subresource Integrity (SRI) support — automatically adds `integrity` and `crossorigin` attributes when `vite-plugin-manifest-sri` is used ([@skryukov])
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ CSS files are detected by extension and emit `<link rel="stylesheet">`:
 <%= vite_tags "application.js", nonce: content_security_policy_nonce %>
 ```
 
+### Subresource Integrity (SRI)
+
+Install the [`vite-plugin-manifest-sri`](https://github.com/nicolo-ribaudo/vite-plugin-manifest-sri) plugin:
+
+```bash
+npm install -D vite-plugin-manifest-sri
+```
+
+```typescript
+import { defineConfig } from 'vite';
+import rails from 'rails-vite-plugin';
+import manifestSRI from 'vite-plugin-manifest-sri';
+
+export default defineConfig({
+  plugins: [
+    rails(),
+    manifestSRI(),
+  ],
+});
+```
+
+That's it — `integrity` and `crossorigin="anonymous"` attributes are automatically added to all script, stylesheet, and modulepreload tags when the manifest includes integrity hashes.
+
 ### Asset Discovery (Images, Fonts)
 
 Use `import.meta.glob` in your entry point to include assets in the Vite manifest:

--- a/lib/rails_vite/manifest.rb
+++ b/lib/rails_vite/manifest.rb
@@ -16,7 +16,8 @@ module RailsVite
 
       {
         file: entry["file"],
-        css: entry.fetch("css", []),
+        integrity: entry["integrity"],
+        css: resolve_css(entry, manifest),
         imports: resolve_imports(entry, Set.new, manifest)
       }
     end
@@ -57,6 +58,13 @@ module RailsVite
       nil
     end
 
+    def resolve_css(entry, manifest)
+      entry.fetch("css", []).map do |css_file|
+        integrity = manifest.values.find { |e| e["file"] == css_file }&.dig("integrity")
+        {file: css_file, integrity: integrity}
+      end
+    end
+
     def resolve_imports(entry, seen, manifest)
       entry.fetch("imports", []).flat_map do |import_key|
         next [] if seen.include?(import_key)
@@ -65,7 +73,8 @@ module RailsVite
         imported = manifest[import_key]
         next [] unless imported
 
-        [imported["file"]] + resolve_imports(imported, seen, manifest)
+        [{file: imported["file"], integrity: imported["integrity"]}] +
+          resolve_imports(imported, seen, manifest)
       end
     end
   end

--- a/lib/rails_vite/tag_helper.rb
+++ b/lib/rails_vite/tag_helper.rb
@@ -68,28 +68,35 @@ module RailsVite
       entries.each do |entry|
         result = RailsVite.manifest.lookup(entry)
 
-        Array(result[:imports]).each do |import_file|
-          next if preloaded.include?(import_file)
-          preloaded.add(import_file)
-          tags << tag.link(rel: "modulepreload", href: vite_asset_url(import_file), nonce: nonce)
+        Array(result[:imports]).each do |import_entry|
+          next if preloaded.include?(import_entry[:file])
+          preloaded.add(import_entry[:file])
+          tags << tag.link(rel: "modulepreload", href: vite_asset_url(import_entry[:file]),
+            nonce: nonce, **sri_attrs(import_entry[:integrity]))
         end
 
-        tags << build_asset_tag(entry, vite_asset_url(result[:file]), nonce: nonce, **options)
+        tags << build_asset_tag(entry, vite_asset_url(result[:file]),
+          nonce: nonce, integrity: result[:integrity], **options)
 
-        Array(result[:css]).each do |css_file|
-          tags << tag.link(rel: "stylesheet", href: vite_asset_url(css_file), nonce: nonce, **options)
+        Array(result[:css]).each do |css_entry|
+          tags << tag.link(rel: "stylesheet", href: vite_asset_url(css_entry[:file]),
+            nonce: nonce, **sri_attrs(css_entry[:integrity]), **options)
         end
       end
 
       safe_join(tags, "\n")
     end
 
-    def build_asset_tag(entry, url, nonce: nil, **options)
+    def build_asset_tag(entry, url, nonce: nil, integrity: nil, **options)
       if css_entry?(entry)
-        tag.link(rel: "stylesheet", href: url, nonce: nonce, **options)
+        tag.link(rel: "stylesheet", href: url, nonce: nonce, **sri_attrs(integrity), **options)
       else
-        tag.script(src: url, type: "module", nonce: nonce, **options)
+        tag.script(src: url, type: "module", nonce: nonce, **sri_attrs(integrity), **options)
       end
+    end
+
+    def sri_attrs(integrity)
+      integrity ? {integrity: integrity, crossorigin: "anonymous"} : {}
     end
 
     def with_default_ext(name, ext)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -39,15 +39,16 @@ class ManifestTest < Minitest::Test
     result = @manifest.lookup("app/javascript/application.js")
 
     assert_equal "assets/application-a1b2c3d4.js", result[:file]
-    assert_equal ["assets/application-x9y8z7w6.css"], result[:css]
-    assert_includes result[:imports], "assets/vendor-b3c4d5e6.js"
+    assert_equal [{file: "assets/application-x9y8z7w6.css", integrity: nil}], result[:css]
+    assert_includes result[:imports].map { |i| i[:file] }, "assets/vendor-b3c4d5e6.js"
   end
 
   def test_lookup_resolves_nested_imports
     result = @manifest.lookup("app/javascript/application.js")
+    import_files = result[:imports].map { |i| i[:file] }
 
-    assert_includes result[:imports], "assets/vendor-b3c4d5e6.js"
-    assert_includes result[:imports], "assets/shared-1234abcd.js"
+    assert_includes import_files, "assets/vendor-b3c4d5e6.js"
+    assert_includes import_files, "assets/shared-1234abcd.js"
   end
 
   def test_lookup_css_entry
@@ -120,7 +121,43 @@ class ManifestTest < Minitest::Test
     manifest = RailsVite::Manifest.new(@manifest_path)
 
     result = manifest.lookup("entry.js")
-    assert_equal ["assets/a.js", "assets/b.js"], result[:imports]
+    assert_equal ["assets/a.js", "assets/b.js"], result[:imports].map { |i| i[:file] }
+  end
+
+  def test_lookup_returns_integrity
+    sri_manifest = {
+      "app/javascript/application.js" => {
+        "file" => "assets/application-a1b2c3d4.js",
+        "isEntry" => true,
+        "integrity" => "sha384-abc123",
+        "css" => ["assets/application-x9y8z7w6.css"],
+        "imports" => ["_vendor-b3c4d5e6"]
+      },
+      "assets/application-x9y8z7w6.css" => {
+        "file" => "assets/application-x9y8z7w6.css",
+        "integrity" => "sha384-css456"
+      },
+      "_vendor-b3c4d5e6" => {
+        "file" => "assets/vendor-b3c4d5e6.js",
+        "integrity" => "sha384-vendor789"
+      }
+    }
+    File.write(@manifest_path, JSON.generate(sri_manifest))
+    manifest = RailsVite::Manifest.new(@manifest_path)
+
+    result = manifest.lookup("app/javascript/application.js")
+
+    assert_equal "sha384-abc123", result[:integrity]
+    assert_equal "sha384-vendor789", result[:imports].first[:integrity]
+    assert_equal "sha384-css456", result[:css].first[:integrity]
+  end
+
+  def test_lookup_returns_nil_integrity_when_absent
+    result = @manifest.lookup("app/javascript/application.js")
+
+    assert_nil result[:integrity]
+    assert_nil result[:imports].first[:integrity]
+    assert_nil result[:css].first[:integrity]
   end
 
   def test_digest_returns_hex_string

--- a/test/tag_helper_test.rb
+++ b/test/tag_helper_test.rb
@@ -332,6 +332,43 @@ class TagHelperTest < Minitest::Test
     assert_match %r{src="http://localhost:5173/app/javascript/application.js".*data-turbo-track="reload"}, html
   end
 
+  # SRI tests
+
+  def test_vite_tags_production_with_sri
+    sri_manifest = {
+      "app/javascript/application.js" => {
+        "file" => "assets/application-a1b2c3d4.js",
+        "isEntry" => true,
+        "integrity" => "sha384-abc123",
+        "css" => ["assets/application-x9y8z7w6.css"],
+        "imports" => ["_vendor-b3c4d5e6"]
+      },
+      "app/javascript/application-x9y8z7w6.css" => {
+        "file" => "assets/application-x9y8z7w6.css",
+        "integrity" => "sha384-css456"
+      },
+      "_vendor-b3c4d5e6" => {
+        "file" => "assets/vendor-b3c4d5e6.js",
+        "integrity" => "sha384-vendor789"
+      }
+    }
+    File.write(@manifest_path, JSON.generate(sri_manifest))
+
+    html = vite_tags("app/javascript/application.js")
+
+    assert_match %r{integrity="sha384-abc123"}, html
+    assert_match %r{crossorigin="anonymous"}, html
+    assert_match %r{rel="modulepreload".*integrity="sha384-vendor789"}, html
+    assert_match %r{rel="stylesheet".*integrity="sha384-css456"}, html
+  end
+
+  def test_vite_tags_production_no_sri_when_absent
+    html = vite_tags("app/javascript/application.js")
+
+    refute_match %r{integrity=}, html
+    refute_match %r{crossorigin=}, html
+  end
+
   # Error tests
 
   def test_missing_entry_raises


### PR DESCRIPTION
This PR makes `rails_vite` automatically add `integrity` and `crossorigin="anonymous"` attributes to `script`, `stylesheet`, and `modulepreload` tags when the Vite manifest includes integrity hashes (via `vite-plugin-manifest-sri`). Zero configuration on the Rails side: if the hashes are in the manifest, they're used, if not, nothing changes.