### PR TITLE
Fix short entry names for entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Short entry names now resolve correctly when using `entrypoints/` directory ([@skryukov])
+
 ## [0.1.1] - 2026-03-08
 
 ### Added

--- a/lib/rails_vite/config.rb
+++ b/lib/rails_vite/config.rb
@@ -20,6 +20,10 @@ module RailsVite
       plugin_meta["sourceDir"] || "app/javascript"
     end
 
+    def entrypoints_dir
+      plugin_meta["entrypointsDir"]
+    end
+
     def auto_build?
       return @auto_build if defined?(@auto_build)
       Rails.env.local?

--- a/lib/rails_vite/tag_helper.rb
+++ b/lib/rails_vite/tag_helper.rb
@@ -4,7 +4,7 @@ module RailsVite
 
     def vite_tags(*entries, nonce: nil, **options)
       config = RailsVite.config
-      resolved = entries.map { |e| resolve_vite_entry(e, config.source_dir) }
+      resolved = entries.map { |e| resolve_vite_entry(e, config.source_dir, config.entrypoints_dir) }
 
       if config.dev_server_running?
         vite_dev_tags(resolved, config.dev_server_url, nonce: nonce, **options)
@@ -103,8 +103,11 @@ module RailsVite
       File.extname(name).empty? ? "#{name}#{ext}" : name
     end
 
-    def resolve_vite_entry(entry, source_dir)
-      entry.start_with?("#{source_dir}/", "/") ? entry : "#{source_dir}/#{entry}"
+    def resolve_vite_entry(entry, source_dir, entrypoints_dir)
+      return entry if entry.start_with?("#{source_dir}/", "/")
+
+      prefix = entrypoints_dir ? "#{source_dir}/#{entrypoints_dir}" : source_dir
+      "#{prefix}/#{entry}"
     end
 
     def vite_asset_url(file)

--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -36,7 +36,8 @@ let exitHandlersBound = false
 
 export default function rails(options: RailsViteOptions = {}): Plugin {
   const sourceDir = options.sourceDir ?? 'app/javascript'
-  const input = options.input ?? detectEntrypoint(sourceDir)
+  const entrypointsDir = options.input === undefined ? detectEntrypointsDir(sourceDir) : null
+  const input = options.input ?? (entrypointsDir ? discoverEntrypointInputs(sourceDir, entrypointsDir) : detectEntrypoint(sourceDir))
   const publicDirectory = options.publicDirectory ?? 'public'
   const buildDirectory = options.buildDirectory ?? 'vite'
   const devMetaPath = options.devMetaFile ?? path.join('tmp', 'rails-vite.json')
@@ -103,7 +104,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
       const outDir = resolvedConfig.build.outDir
       fs.writeFileSync(
         path.join(outDir, 'rails-vite.json'),
-        JSON.stringify({ sourceDir })
+        JSON.stringify(entrypointsDir ? { sourceDir, entrypointsDir } : { sourceDir })
       )
     },
 
@@ -116,6 +117,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
           resolvedConfig.server.origin = devServerUrl
 
           const meta: Record<string, unknown> = { url: devServerUrl, sourceDir }
+          if (entrypointsDir) meta.entrypointsDir = entrypointsDir
           if (reactRefresh) meta.reactRefresh = true
           fs.writeFileSync(devMetaPath, JSON.stringify(meta))
 
@@ -196,14 +198,19 @@ function prefixWithSourceDir(entry: string, sourceDir: string): string {
 
 const entrypointExtensions = /\.(mjs|js|mts|ts|jsx|tsx|css|scss|sass|less|styl|pcss)$/
 
-function detectEntrypoint(sourceDir: string): string | string[] {
+function detectEntrypointsDir(sourceDir: string): string | null {
   const entrypointsDir = path.join(sourceDir, 'entrypoints')
-  if (fs.existsSync(entrypointsDir)) {
-    return discoverEntrypoints(entrypointsDir).map(
-      (entry) => `entrypoints/${entry}`
-    )
-  }
+  return fs.existsSync(entrypointsDir) ? 'entrypoints' : null
+}
 
+function discoverEntrypointInputs(sourceDir: string, entrypointsDir: string): string[] {
+  const absDir = path.join(sourceDir, entrypointsDir)
+  return discoverEntrypoints(absDir).map(
+    (entry) => `${entrypointsDir}/${entry}`
+  )
+}
+
+function detectEntrypoint(sourceDir: string): string {
   for (const ext of ['.js', '.mjs', '.ts', '.mts', '.jsx', '.tsx']) {
     const candidate = path.join(sourceDir, `application${ext}`)
     if (fs.existsSync(candidate)) {

--- a/test/tag_helper_test.rb
+++ b/test/tag_helper_test.rb
@@ -207,6 +207,48 @@ class TagHelperTest < Minitest::Test
     assert_match %r{src="/vite/assets/app-rel123.js"}, html
   end
 
+  # entrypointsDir resolution tests
+
+  def test_vite_tags_entrypoints_dir_production
+    File.write(File.join(File.dirname(@manifest_path), "rails-vite.json"),
+      '{"sourceDir":"app/frontend","entrypointsDir":"entrypoints"}')
+
+    custom_manifest = {
+      "app/frontend/entrypoints/application.js" => {
+        "file" => "assets/application-ep123.js",
+        "isEntry" => true, "css" => [], "imports" => []
+      },
+      "app/frontend/entrypoints/application.css" => {
+        "file" => "assets/application-ep456.css",
+        "isEntry" => true
+      }
+    }
+    File.write(@manifest_path, JSON.generate(custom_manifest))
+
+    html = vite_stylesheet_tag("application.css", "data-turbo-track": "reload")
+
+    assert_match %r{rel="stylesheet".*href="/vite/assets/application-ep456.css"}, html
+    assert_match %r{data-turbo-track="reload"}, html
+  end
+
+  def test_vite_tags_entrypoints_dir_dev_mode
+    File.write(File.join(@dir, "rails-vite.json"),
+      '{"url":"http://localhost:5173","sourceDir":"app/frontend","entrypointsDir":"entrypoints"}')
+
+    html = vite_tags("application.js")
+
+    assert_match %r{src="http://localhost:5173/app/frontend/entrypoints/application.js"}, html
+  end
+
+  def test_vite_tags_entrypoints_dir_full_path_not_affected
+    File.write(File.join(File.dirname(@manifest_path), "rails-vite.json"),
+      '{"sourceDir":"app/javascript","entrypointsDir":"entrypoints"}')
+
+    html = vite_tags("app/javascript/application.js")
+
+    assert_match %r{src="/vite/assets/application-a1b2c3d4.js"}, html
+  end
+
   # React refresh preamble tests
 
   def test_vite_tags_dev_mode_with_react_refresh


### PR DESCRIPTION
This PR fixes short names like "application.css" resolving for entrypoints from `sourceDir/entrypoints/` directory.