### PR TITLE
Jsbundling mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- jsbundling mode — use Vite as a bundler with `jsbundling-rails` and Propshaft, no gem required ([@skryukov])
+
 ## [0.1.2] - 2026-03-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Vite integration for Rails, inspired by [Laravel's Vite plugin](https://laravel.
 - [Testing the Build](#testing-the-build)
 - [Custom Paths](#custom-paths)
 - [Rake Tasks](#rake-tasks)
+- [jsbundling Mode](#jsbundling-mode)
 - [Migrating from vite_rails](#migrating-from-vite_rails)
 - [Contributing](#contributing)
 - [License](#license)
@@ -316,6 +317,80 @@ Defaults match the plugin defaults — no config needed if you follow convention
 
 `vite:build` hooks into `assets:precompile` and `test:prepare` automatically. Skip with `SKIP_VITE_BUILD=1`.
 
+
+## jsbundling Mode
+
+If you're using [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) with Propshaft and want Vite as your bundler, you don't need the `rails_vite` gem — just the npm package:
+
+```bash
+npm install -D rails-vite-plugin vite
+```
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import jsbundling from 'rails-vite-plugin/jsbundling';
+
+export default defineConfig({
+  plugins: [
+    jsbundling(),
+  ],
+});
+```
+
+**How it works:** In production, Vite builds to `public/assets/` and copies entry files to `app/assets/builds/` so Propshaft can serve them via `javascript_include_tag` and `stylesheet_link_tag`. In development, the plugin writes stub files to `app/assets/builds/` that redirect the browser to Vite's dev server for HMR.
+
+### jsbundling Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `input` | auto-detected | Entry point(s). If `sourceDir/entrypoints/` exists, all files in it are used. Otherwise, detects `application.{js,ts,jsx,tsx}` in `sourceDir` |
+| `sourceDir` | `'app/javascript'` | Source directory. Short names are prefixed with this. Also sets the `@` import alias |
+| `assetPipelineDir` | `'app/assets/builds'` | Directory where Propshaft/Sprockets picks up entry files |
+| `outputDir` | `'public/assets'` | Public directory for the full Vite build output |
+| `ssr` | — | SSR entry point. String or `{ entry, outDir }` |
+| `refresh` | — | Paths to watch for full-page reload. `true` watches `app/views/**` and `app/helpers/**` |
+| `devMetaFile` | `'tmp/rails-vite.json'` | Dev metadata file path. Set to `false` to disable |
+
+### Replacing esbuild
+
+In your `Procfile.dev`, replace the esbuild command:
+
+```
+web: bin/rails server -p 3000
+-js: yarn build --watch
++vite: npx vite
+```
+
+CSS and JS entries in `app/javascript/entrypoints/` are auto-discovered. Both `javascript_include_tag` and `stylesheet_link_tag` work unchanged — Propshaft resolves them from `app/assets/builds/` as before.
+
+### Frameworks
+
+React and Vue work the same as in the standard plugin — add the framework plugin before `jsbundling()`:
+
+```typescript
+import { defineConfig } from 'vite';
+import jsbundling from 'rails-vite-plugin/jsbundling';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    jsbundling(),
+  ],
+});
+```
+
+### Upgrading to rails_vite
+
+To switch from jsbundling mode to the full `rails_vite` gem:
+
+1. Add `gem "rails_vite"` to your Gemfile and `bundle install`
+2. Change the import in `vite.config.ts` from `rails-vite-plugin/jsbundling` to `rails-vite-plugin`
+3. Replace `javascript_include_tag` / `stylesheet_link_tag` with `vite_tags` in your layouts
+4. Remove `jsbundling-rails` from your Gemfile
+
+In development, jsbundling mode writes `tmp/rails-vite.json` — the same file the `rails_vite` gem reads. You can add the gem and verify `vite_tags` works in dev before deploying.
 
 ## Migrating from vite_rails
 

--- a/packages/rails-vite-plugin/package.json
+++ b/packages/rails-vite-plugin/package.json
@@ -11,6 +11,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./jsbundling": {
+      "import": "./dist/jsbundling.js",
+      "types": "./dist/jsbundling.d.ts"
     }
   },
   "files": [
@@ -43,6 +47,8 @@
   "keywords": [
     "vite",
     "rails",
+    "jsbundling",
+    "jsbundling-rails",
     "vite-plugin"
   ],
   "homepage": "https://github.com/skryukov/rails_vite",

--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -1,0 +1,390 @@
+import fs from 'fs'
+import path from 'path'
+import picomatch from 'picomatch'
+import {
+  Plugin,
+  UserConfig,
+  ConfigEnv,
+  ResolvedConfig,
+  loadEnv,
+  defaultAllowedOrigins,
+} from 'vite'
+
+import type { InputOption, ResolvedEntry } from './shared/types.js'
+import { resolveEntries, entriesToRollupInput, prefixWithSourceDir, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint, isEntrypointFile } from './shared/entries.js'
+import { resolveAlias } from './shared/alias.js'
+import { resolveDevServerUrl, isAddressInfo } from './shared/dev-server.js'
+import { ensureCommandShouldRunInEnvironment } from './shared/env-guard.js'
+import { refreshPaths, resolveRefreshPaths } from './shared/refresh.js'
+import { cssExtensions } from './shared/css.js'
+import { readDevServerIndexHtml } from './shared/dev-server-page.js'
+import { resolveNoExternal } from './shared/ssr.js'
+import { bindExitHandler } from './shared/cleanup.js'
+
+export type { InputOption }
+export { refreshPaths }
+
+const CSS_FACADE_PREFIX = '_css_'
+
+export interface JsbundlingOptions {
+  input?: InputOption
+  sourceDir?: string
+  /** Directory where Propshaft/Sprockets picks up entry files for Rails helpers.
+   *  Default: 'app/assets/builds' */
+  assetPipelineDir?: string
+  /** Public directory for the full Vite build output (chunks, assets).
+   *  Default: 'public/assets' */
+  outputDir?: string
+  /** SSR entry point for Inertia server-side rendering.
+   *  String is a path relative to sourceDir (e.g., 'ssr/ssr.tsx').
+   *  Object form allows customizing the output directory. */
+  ssr?: string | { entry: string; outDir?: string }
+  refresh?: boolean | string | string[]
+  /** Path to write dev server metadata JSON (default: 'tmp/rails-vite.json').
+   *  Set to false to disable. Useful as a bridge for progressive upgrade to the rails_vite gem. */
+  devMetaFile?: string | false
+}
+
+export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
+  const sourceDir = options.sourceDir ?? 'app/javascript'
+  const epDir = detectEntrypointsDir(sourceDir)
+  const input = options.input ?? (epDir ? discoverEntrypointInputs(sourceDir, epDir) : detectEntrypoint(sourceDir))
+  const assetPipelineDir = options.assetPipelineDir ?? 'app/assets/builds'
+  const outputDir = options.outputDir ?? 'public/assets'
+  // The URL prefix matching outputDir under public/ — used as Vite's `base` in production
+  // so that dynamic import() URLs resolve to the right place.
+  const buildBase = '/' + path.relative('public', outputDir) + '/'
+  const devMetaPath = options.devMetaFile !== false
+    ? (options.devMetaFile ?? path.join('tmp', 'rails-vite.json'))
+    : null
+
+  const entries = resolveEntries(input, sourceDir)
+  const rollupInput = entriesToRollupInput(entries, typeof options.input === 'object' && !Array.isArray(options.input))
+  const ssrConfig = resolveSsrConfig(options.ssr, sourceDir, outputDir)
+
+  let resolvedConfig: ResolvedConfig
+  let reactRefresh = false
+
+  // Track stubs written in dev so we can clean them up
+  const writtenStubs: string[] = []
+
+  return {
+    name: 'rails-vite-jsbundling',
+    enforce: 'post',
+
+    config(userConfig: UserConfig, { command, mode, isSsrBuild }: ConfigEnv): UserConfig {
+      const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
+
+      ensureCommandShouldRunInEnvironment(command, env, 'rails-vite-plugin/jsbundling')
+
+      // SSR builds get minimal config — just entry, outDir, base, and alias.
+      // No asset pipeline stubs or client-specific settings.
+      if (isSsrBuild) {
+        return {
+          base: userConfig.base ?? (command === 'build' ? buildBase : ''),
+          publicDir: userConfig.publicDir ?? false,
+          ...(ssrConfig ? {
+            build: {
+              ssrManifest: userConfig.build?.ssrManifest ?? 'ssr-manifest.json',
+              outDir: userConfig.build?.outDir ?? ssrConfig.outDir,
+              rollupOptions: {
+                input: userConfig.build?.rollupOptions?.input ?? ssrConfig.entry,
+              },
+            },
+          } : {}),
+          resolve: {
+            alias: resolveAlias(userConfig.resolve?.alias, sourceDir),
+          },
+          ssr: {
+            noExternal: resolveNoExternal(userConfig),
+          },
+        }
+      }
+
+      // In dev mode, write placeholder stubs immediately so Propshaft/Sprockets
+      // can discover them when Rails boots (both may start concurrently via bin/dev).
+      if (command === 'serve') {
+        writePlaceholderStubs(entries, assetPipelineDir, writtenStubs)
+      }
+
+      return {
+        base: userConfig.base ?? (command === 'build' ? buildBase : ''),
+        publicDir: userConfig.publicDir ?? false,
+        build: {
+          manifest: userConfig.build?.manifest ?? false,
+          outDir: userConfig.build?.outDir ?? outputDir,
+          rollupOptions: {
+            input: userConfig.build?.rollupOptions?.input ?? rollupInput,
+            output: {
+              entryFileNames: (chunkInfo: { facadeModuleId?: string | null }) => {
+                if (chunkInfo.facadeModuleId && cssExtensions.test(chunkInfo.facadeModuleId)) {
+                  return `${CSS_FACADE_PREFIX}[name].js`
+                }
+                return '[name].js'
+              },
+              chunkFileNames: '[name]-[hash].js',
+              assetFileNames: '[name][extname]',
+            },
+          },
+          assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
+          cssCodeSplit: true,
+        },
+        server: {
+          cors: userConfig.server?.cors ?? {
+            origin: userConfig.server?.origin ?? defaultAllowedOrigins,
+          },
+        },
+        resolve: {
+          alias: resolveAlias(userConfig.resolve?.alias, sourceDir),
+        },
+        ssr: {
+          noExternal: resolveNoExternal(userConfig),
+        },
+      }
+    },
+
+    configResolved(config) {
+      resolvedConfig = config
+      reactRefresh = config.plugins.some((p) => p.name === 'vite:react-babel' || p.name === 'vite:react-swc')
+    },
+
+    generateBundle(_, bundle) {
+      // Rollup wraps CSS entries in empty JS facade chunks. Delete them —
+      // the real CSS is emitted as an asset by Vite's CSS pipeline.
+      for (const fileName of Object.keys(bundle)) {
+        if (fileName.startsWith(CSS_FACADE_PREFIX)) {
+          delete bundle[fileName]
+        }
+      }
+    },
+
+    writeBundle(_, bundle) {
+      // SSR bundles are Node.js server code — not served to browsers.
+      if (resolvedConfig.build.ssr) return
+
+      // Copy entry files (JS + CSS) to the asset pipeline directory
+      // so Propshaft/Sprockets can serve them via Rails helpers.
+      // Chunks stay in outputDir and are served directly by the web server.
+      fs.mkdirSync(assetPipelineDir, { recursive: true })
+
+      const outDir = resolvedConfig.build.outDir
+      // Only copy CSS files that correspond to entries (entry CSS or CSS extracted
+      // from JS entries). Shared chunk CSS stays in outputDir.
+      const entryNames = new Set(entries.map(e => e.name))
+
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        const isEntryJs = chunk.type === 'chunk' && chunk.isEntry
+        const isEntryCss = chunk.type === 'asset' && cssExtensions.test(fileName)
+          && entryNames.has(fileName.replace(/\.[^.]+$/, ''))
+
+        if (isEntryJs || isEntryCss) {
+          const src = path.join(outDir, fileName)
+          const dest = path.join(assetPipelineDir, fileName)
+          fs.mkdirSync(path.dirname(dest), { recursive: true })
+          fs.copyFileSync(src, dest)
+        }
+      }
+    },
+
+    configureServer(server) {
+      let devServerUrl: string | null = null
+      let syncTimer: ReturnType<typeof setTimeout> | null = null
+
+      // Re-discover entries from the entrypoints dir and regenerate all stubs.
+      // Called on initial listen and whenever entrypoint files are added/removed.
+      const syncStubs = () => {
+        if (!devServerUrl) return
+        const freshInput = epDir ? discoverEntrypointInputs(sourceDir, epDir) : input
+        const freshEntries = resolveEntries(freshInput, sourceDir)
+
+        // Clear old stubs
+        for (const stub of writtenStubs) {
+          fs.rmSync(stub, { force: true })
+        }
+        writtenStubs.length = 0
+
+        writeDevStubs(freshEntries, assetPipelineDir, devServerUrl, reactRefresh, writtenStubs)
+      }
+
+      // Debounced version for watcher events — collapses burst operations
+      // (e.g., pasting multiple files, git checkout) into a single rescan.
+      const debouncedSyncStubs = () => {
+        if (syncTimer) clearTimeout(syncTimer)
+        syncTimer = setTimeout(syncStubs, 100)
+      }
+
+      server.httpServer?.once('listening', () => {
+        const address = server.httpServer?.address()
+
+        if (isAddressInfo(address)) {
+          devServerUrl = resolveDevServerUrl(address, resolvedConfig)
+
+          syncStubs()
+
+          // Write dev meta file for progressive upgrade to the rails_vite gem
+          if (devMetaPath) {
+            const meta: Record<string, unknown> = { url: devServerUrl, sourceDir }
+            if (epDir) meta.entrypointsDir = epDir
+            if (reactRefresh) meta.reactRefresh = true
+            meta.jsbundling = true
+            fs.mkdirSync(path.dirname(devMetaPath), { recursive: true })
+            fs.writeFileSync(devMetaPath, JSON.stringify(meta))
+          }
+
+          // Watch entrypoints dir for new/removed files and regenerate stubs
+          if (epDir) {
+            const epAbsDir = path.resolve(sourceDir, epDir)
+            server.watcher.add(epAbsDir)
+            const epAbsDirPrefix = epAbsDir + '/'
+            server.watcher.on('add', (filePath: string) => {
+              if (filePath.startsWith(epAbsDirPrefix) && isEntrypointFile(filePath)) {
+                server.config.logger.info(`  RAILS  new entrypoint: ${path.relative(sourceDir, filePath)}`)
+                debouncedSyncStubs()
+              }
+            })
+            server.watcher.on('unlink', (filePath: string) => {
+              if (filePath.startsWith(epAbsDirPrefix) && isEntrypointFile(filePath)) {
+                server.config.logger.info(`  RAILS  removed entrypoint: ${path.relative(sourceDir, filePath)}`)
+                debouncedSyncStubs()
+              }
+            })
+          }
+
+          server.config.logger.info(
+            `\n  RAILS  rails-vite-plugin/jsbundling → ${assetPipelineDir}`
+          )
+        }
+      })
+
+      bindExitHandler(() => {
+        for (const stub of writtenStubs) {
+          fs.rmSync(stub, { force: true })
+        }
+        writtenStubs.length = 0
+        if (devMetaPath) {
+          fs.rmSync(devMetaPath, { force: true })
+        }
+      })
+
+      // Watch view templates for full-page reload
+      const resolvedRefreshPaths = resolveRefreshPaths(options.refresh)
+      if (resolvedRefreshPaths.length) {
+        const match = picomatch(resolvedRefreshPaths)
+        server.watcher.add(resolvedRefreshPaths)
+        server.watcher.on('change', (filePath: string) => {
+          const relativePath = path.relative(process.cwd(), filePath)
+          if (match(relativePath)) {
+            server.hot.send({ type: 'full-reload', path: '*' })
+          }
+        })
+      }
+
+      const devServerIndexHtml = readDevServerIndexHtml()
+
+      return () =>
+        server.middlewares.use((req, res, next) => {
+          if (req.url === '/index.html') {
+            res.statusCode = 404
+            res.setHeader('Content-Type', 'text/html')
+            res.end(devServerIndexHtml)
+            return
+          }
+          next()
+        })
+    },
+  }
+}
+
+function resolveSsrConfig(
+  ssr: JsbundlingOptions['ssr'],
+  sourceDir: string,
+  outputDir: string,
+): { entry: string; outDir: string } | null {
+  if (!ssr) return null
+  const entry = typeof ssr === 'string' ? ssr : ssr.entry
+  const outDir = (typeof ssr === 'object' ? ssr.outDir : undefined) ?? outputDir + '-ssr'
+  return {
+    entry: prefixWithSourceDir(entry, sourceDir),
+    outDir,
+  }
+}
+
+/**
+ * Write placeholder stubs so Propshaft/Sprockets can discover asset files
+ * at boot time, before the Vite dev server is ready with its URL.
+ * Writes unconditionally — stubs are overwritten by writeDevStubs once the server is listening.
+ */
+function writePlaceholderStubs(
+  entries: ResolvedEntry[],
+  outDir: string,
+  writtenStubs: string[],
+): void {
+  fs.mkdirSync(outDir, { recursive: true })
+
+  const seen = new Set<string>()
+  for (const { name } of entries) {
+    if (seen.has(name)) continue
+    seen.add(name)
+
+    const jsStub = path.join(outDir, `${name}.js`)
+    fs.mkdirSync(path.dirname(jsStub), { recursive: true })
+    fs.writeFileSync(jsStub, '// rails-vite placeholder – loading…\n')
+    writtenStubs.push(jsStub)
+
+    const cssStub = path.join(outDir, `${name}.css`)
+    fs.writeFileSync(cssStub, '/* rails-vite placeholder – loading… */\n')
+    writtenStubs.push(cssStub)
+  }
+}
+
+function writeDevStubs(
+  entries: ResolvedEntry[],
+  outDir: string,
+  devServerUrl: string,
+  reactRefresh: boolean,
+  writtenStubs: string[],
+): void {
+  fs.mkdirSync(outDir, { recursive: true })
+
+  const importLine = (url: string) =>
+    reactRefresh ? `await import("${url}");` : `import "${url}";`
+
+  const jsEntries = entries.filter(e => !cssExtensions.test(e.sourcePath))
+  const cssEntries = entries.filter(e => cssExtensions.test(e.sourcePath))
+
+  // JS stubs: import @vite/client + all CSS entries (for HMR) + the JS entry itself.
+  for (const { name, sourcePath } of jsEntries) {
+    const stubPath = path.join(outDir, `${name}.js`)
+    fs.mkdirSync(path.dirname(stubPath), { recursive: true })
+    const lines = ['// rails-vite dev stub – DO NOT EDIT']
+    if (reactRefresh) {
+      // Static import for the refresh runtime — just exports a function, safe to hoist.
+      // Everything else uses dynamic import() so the preamble executes first
+      // (static imports hoist, so injectIntoGlobalHook would run after all modules).
+      lines.push(`import { injectIntoGlobalHook } from "${devServerUrl}/@react-refresh";`)
+      lines.push('injectIntoGlobalHook(window);')
+      lines.push('window.$RefreshReg$ = () => {};')
+      lines.push('window.$RefreshSig$ = () => (type) => type;')
+    }
+    lines.push(importLine(`${devServerUrl}/@vite/client`))
+    // Import CSS entries so Vite's module graph tracks them for HMR
+    for (const { sourcePath: cssPath } of cssEntries) {
+      lines.push(importLine(`${devServerUrl}/${cssPath}`))
+    }
+    lines.push(importLine(`${devServerUrl}/${sourcePath}`))
+    fs.writeFileSync(stubPath, lines.join('\n') + '\n')
+    writtenStubs.push(stubPath)
+  }
+
+  // Empty CSS stubs so stylesheet_link_tag doesn't error.
+  // Actual CSS is injected by @vite/client through the JS imports above.
+  const seen = new Set<string>()
+  for (const { name } of entries) {
+    if (seen.has(name)) continue
+    seen.add(name)
+    const cssStubPath = path.join(outDir, `${name}.css`)
+    fs.mkdirSync(path.dirname(cssStubPath), { recursive: true })
+    fs.writeFileSync(cssStubPath, '/* rails-vite dev stub */\n')
+    writtenStubs.push(cssStubPath)
+  }
+}

--- a/packages/rails-vite-plugin/tests/jsbundling.test.ts
+++ b/packages/rails-vite-plugin/tests/jsbundling.test.ts
@@ -1,0 +1,808 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import type { ConfigEnv, Plugin, UserConfig } from 'vite'
+import jsbundling, { refreshPaths } from '../src/jsbundling'
+import { bindExitHandler } from '../src/shared/cleanup'
+
+const BUILD: ConfigEnv = { command: 'build', mode: 'production' }
+const SSR_BUILD: ConfigEnv = { command: 'build', mode: 'production', isSsrBuild: true }
+const SERVE: ConfigEnv = { command: 'serve', mode: 'development' }
+
+function getConfig(plugin: Plugin, userConfig: UserConfig = {}, env: ConfigEnv = BUILD): UserConfig {
+  return (plugin.config as (config: UserConfig, env: ConfigEnv) => UserConfig)(userConfig, env)
+}
+
+function callConfigResolved(plugin: Plugin, overrides: Record<string, unknown> = {}) {
+  ;(plugin.configResolved as Function)({
+    build: { ssr: false, outDir: 'public/assets' },
+    plugins: [],
+    server: { hmr: false, https: false, host: 'localhost' },
+    ...overrides,
+  })
+}
+
+function callWriteBundle(plugin: Plugin, bundle: Record<string, unknown>) {
+  ;(plugin.writeBundle as Function)({}, bundle)
+}
+
+interface MockServer {
+  httpServer: {
+    once: (event: string, cb: Function) => void
+    address: () => { address: string; port: number; family: string }
+  }
+  watcher: {
+    add: ReturnType<typeof vi.fn>
+    on: (event: string, cb: Function) => void
+  }
+  config: { logger: { info: ReturnType<typeof vi.fn> } }
+  hot: { send: ReturnType<typeof vi.fn> }
+  middlewares: { use: ReturnType<typeof vi.fn> }
+  _emit: (event: string, ...args: unknown[]) => void
+  _emitWatcher: (event: string, ...args: unknown[]) => void
+}
+
+function createMockServer(): MockServer {
+  const eventListeners: Record<string, Function[]> = {}
+  const watcherListeners: Record<string, Function[]> = {}
+
+  return {
+    httpServer: {
+      once(event: string, cb: Function) {
+        eventListeners[event] = eventListeners[event] || []
+        eventListeners[event].push(cb)
+      },
+      address: () => ({ address: '127.0.0.1', port: 5173, family: 'IPv4' }),
+    },
+    watcher: {
+      add: vi.fn(),
+      on(event: string, cb: Function) {
+        watcherListeners[event] = watcherListeners[event] || []
+        watcherListeners[event].push(cb)
+      },
+    },
+    config: { logger: { info: vi.fn() } },
+    hot: { send: vi.fn() },
+    middlewares: { use: vi.fn() },
+    _emit(event: string, ...args: unknown[]) {
+      for (const cb of eventListeners[event] || []) cb(...args)
+    },
+    _emitWatcher(event: string, ...args: unknown[]) {
+      for (const cb of watcherListeners[event] || []) cb(...args)
+    },
+  }
+}
+
+vi.mock('../src/shared/cleanup.js', () => ({
+  bindExitHandler: vi.fn(),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    default: {
+      ...actual,
+      existsSync: (filePath: string) => {
+        // Mock: app/javascript/application.js exists for auto-detection
+        if (filePath.endsWith('app/javascript/application.js')) return true
+        // Mock: app/frontend/application.ts exists
+        if (filePath.endsWith('app/frontend/application.ts')) return true
+        // Mock: app/assets/entrypoints directory exists
+        if (filePath.endsWith('app/assets/entrypoints')) return true
+        return actual.existsSync(filePath)
+      },
+      readdirSync: (dir: string, options?: { withFileTypes: boolean }) => {
+        if (dir.endsWith('app/assets/entrypoints') && options?.withFileTypes) {
+          return [
+            { name: 'application.ts', isDirectory: () => false },
+            { name: 'application.css', isDirectory: () => false },
+            { name: 'README.md', isDirectory: () => false },
+            { name: 'admin', isDirectory: () => true },
+          ]
+        }
+        if (dir.endsWith('app/assets/entrypoints/admin') && options?.withFileTypes) {
+          return [
+            { name: 'index.tsx', isDirectory: () => false },
+          ]
+        }
+        return actual.readdirSync(dir, options as Parameters<typeof actual.readdirSync>[1])
+      },
+      readFileSync: (filePath: string, encoding?: string) => {
+        if (typeof filePath === 'string' && filePath.includes('dev-server-index.html')) {
+          return '<html><body>Vite Dev Server</body></html>'
+        }
+        return actual.readFileSync(filePath, encoding as BufferEncoding)
+      },
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      copyFileSync: vi.fn(),
+      rmSync: vi.fn(),
+    },
+  }
+})
+
+describe('rails-vite-plugin/jsbundling', () => {
+  afterEach(() => {
+    delete process.env.CI
+    delete process.env.RAILS_ENV
+    vi.mocked(fs.mkdirSync).mockClear()
+    vi.mocked(fs.writeFileSync).mockClear()
+    vi.mocked(fs.copyFileSync).mockClear()
+    vi.mocked(fs.rmSync).mockClear()
+    vi.mocked(bindExitHandler).mockClear()
+  })
+
+  // --- Input handling ---
+
+  it('auto-detects application.js entry point', () => {
+    const plugin = jsbundling()
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/javascript/application.js')
+  })
+
+  it('auto-detects application.ts with custom sourceDir', () => {
+    const plugin = jsbundling({ sourceDir: 'app/frontend' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/frontend/application.ts')
+  })
+
+  it('accepts a single input', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/javascript/application.js')
+  })
+
+  it('accepts an array of inputs', () => {
+    const plugin = jsbundling({
+      input: ['application.js', 'admin.js'],
+    })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toEqual([
+      'app/javascript/application.js',
+      'app/javascript/admin.js',
+    ])
+  })
+
+  it('does not prefix entries that already include sourceDir', () => {
+    const plugin = jsbundling({ input: 'app/javascript/application.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/javascript/application.js')
+  })
+
+  it('does not prefix absolute paths', () => {
+    const plugin = jsbundling({ input: '/absolute/path.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('/absolute/path.js')
+  })
+
+  it('accepts an object input (named entries)', () => {
+    const plugin = jsbundling({
+      input: { app: 'application.js', admin: 'admin/index.js' },
+    })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toEqual({
+      app: 'app/javascript/application.js',
+      admin: 'app/javascript/admin/index.js',
+    })
+  })
+
+  it('auto-discovers entrypoints directory', () => {
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toEqual([
+      'app/assets/entrypoints/application.ts',
+      'app/assets/entrypoints/application.css',
+      'app/assets/entrypoints/admin/index.tsx',
+    ])
+  })
+
+  it('filters non-entrypoint files from discovery', () => {
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+
+    const config = getConfig(plugin)
+    const input = config!.build!.rollupOptions!.input as string[]
+    expect(input).not.toContainEqual(expect.stringContaining('README.md'))
+  })
+
+  it('explicit input takes precedence over entrypoints directory', () => {
+    const plugin = jsbundling({ sourceDir: 'app/assets', input: 'custom.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.rollupOptions!.input).toBe('app/assets/custom.js')
+  })
+
+  // --- Build config defaults ---
+
+  it('builds to public/assets with /assets/ base', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.base).toBe('/assets/')
+    expect(config!.build!.outDir).toBe('public/assets')
+  })
+
+  it('sets empty base for dev server', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, {}, SERVE)
+    expect(config!.base).toBe('')
+  })
+
+  it('sets correct build defaults', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.manifest).toBe(false)
+    expect(config!.build!.assetsInlineLimit).toBe(0)
+    expect(config!.publicDir).toBe(false)
+  })
+
+  it('uses unhashed entry filenames', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    const output = config!.build!.rollupOptions!.output as Record<string, unknown>
+    expect(output.assetFileNames).toBe('[name][extname]')
+    expect(output.chunkFileNames).toBe('[name]-[hash].js')
+    // entryFileNames is a function for CSS facade handling
+    const entryFileNames = output.entryFileNames as Function
+    expect(entryFileNames({ facadeModuleId: 'app/javascript/application.js' })).toBe('[name].js')
+  })
+
+  it('prefixes CSS facade entry filenames with _css_', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    const output = config!.build!.rollupOptions!.output as Record<string, unknown>
+    const entryFileNames = output.entryFileNames as Function
+    expect(entryFileNames({ facadeModuleId: 'app/javascript/styles.css' })).toBe('_css_[name].js')
+    expect(entryFileNames({ facadeModuleId: 'app/javascript/theme.scss' })).toBe('_css_[name].js')
+    expect(entryFileNames({ facadeModuleId: null })).toBe('[name].js')
+  })
+
+  it('uses custom outputDir', () => {
+    const plugin = jsbundling({
+      input: 'application.js',
+      outputDir: 'public/assets/builds',
+    })
+
+    const config = getConfig(plugin)
+    expect(config!.build!.outDir).toBe('public/assets/builds')
+    expect(config!.base).toBe('/assets/builds/')
+  })
+
+  it('derives base from custom outputDir relative to public/', () => {
+    const plugin = jsbundling({
+      input: 'application.js',
+      outputDir: 'public/my-app',
+    })
+
+    const config = getConfig(plugin)
+    expect(config!.base).toBe('/my-app/')
+  })
+
+  // --- User config passthrough ---
+
+  it('respects user base config', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { base: '/custom/' })
+    expect(config!.base).toBe('/custom/')
+  })
+
+  it('respects user manifest config', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { build: { manifest: 'custom-manifest.json' } })
+    expect(config!.build!.manifest).toBe('custom-manifest.json')
+  })
+
+  it('respects user outDir config', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { build: { outDir: 'custom/output' } })
+    expect(config!.build!.outDir).toBe('custom/output')
+  })
+
+  it('respects user rollupOptions.input', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { build: { rollupOptions: { input: 'custom/entry.js' } } })
+    expect(config!.build!.rollupOptions!.input).toBe('custom/entry.js')
+  })
+
+  it('respects user server.cors config', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { server: { cors: true } }, SERVE)
+    expect(config!.server!.cors).toBe(true)
+  })
+
+  // --- @ alias ---
+
+  it('provides @ alias by default', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin)
+    expect((config!.resolve!.alias as Record<string, string>)['@']).toBe(
+      path.resolve(process.cwd(), 'app/javascript'),
+    )
+  })
+
+  it('provides @ alias with custom sourceDir', () => {
+    const plugin = jsbundling({ input: 'application.ts', sourceDir: 'app/frontend' })
+
+    const config = getConfig(plugin)
+    expect((config!.resolve!.alias as Record<string, string>)['@']).toBe(
+      path.resolve(process.cwd(), 'app/frontend'),
+    )
+  })
+
+  it('respects existing @ alias (object form)', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, { resolve: { alias: { '@': '/custom/path' } } })
+    expect((config!.resolve!.alias as Record<string, string>)['@']).toBe('/custom/path')
+  })
+
+  it('respects existing @ alias (array form)', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(
+      plugin,
+      { resolve: { alias: [{ find: '@', replacement: '/custom/path' }] } },
+    )
+    expect(config!.resolve!.alias).toEqual([
+      { find: '@', replacement: '/custom/path' },
+    ])
+  })
+
+  it('appends @ alias to array when not present', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(
+      plugin,
+      { resolve: { alias: [{ find: '~', replacement: '/other' }] } },
+    )
+    expect(config!.resolve!.alias).toEqual([
+      { find: '~', replacement: '/other' },
+      { find: '@', replacement: path.resolve(process.cwd(), 'app/javascript') },
+    ])
+  })
+
+  // --- SSR builds ---
+
+  it('returns SSR entry and outDir when ssr option is set', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.build!.rollupOptions!.input).toBe('app/frontend/ssr/ssr.tsx')
+    expect(config!.build!.outDir).toBe('public/assets-ssr')
+  })
+
+  it('uses custom SSR outDir', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: { entry: 'ssr/ssr.tsx', outDir: 'public/vite-ssr' },
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.build!.outDir).toBe('public/vite-ssr')
+  })
+
+  it('generates SSR manifest', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.build!.ssrManifest).toBe('ssr-manifest.json')
+  })
+
+  it('provides base and alias for SSR builds', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.base).toBe('/assets/')
+    expect((config!.resolve!.alias as Record<string, string>)['@']).toBe(
+      path.resolve(process.cwd(), 'app/frontend'),
+    )
+  })
+
+  it('does not set client-specific config for SSR builds', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.build!.assetsInlineLimit).toBeUndefined()
+    expect(config!.build!.cssCodeSplit).toBeUndefined()
+    expect(config!.publicDir).toBe(false)
+  })
+
+  it('skips build config for SSR builds without ssr option', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.build).toBeUndefined()
+    // Still provides alias
+    expect((config!.resolve!.alias as Record<string, string>)['@']).toBe(
+      path.resolve(process.cwd(), 'app/javascript'),
+    )
+  })
+
+  it('respects user overrides for SSR builds', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {
+      build: { outDir: 'custom/ssr', rollupOptions: { input: 'custom-ssr.tsx' } },
+    }, SSR_BUILD)
+    expect(config!.build!.outDir).toBe('custom/ssr')
+    expect(config!.build!.rollupOptions!.input).toBe('custom-ssr.tsx')
+  })
+
+  it('adds noExternal for SSR builds', () => {
+    const plugin = jsbundling({
+      sourceDir: 'app/frontend',
+      ssr: 'ssr/ssr.tsx',
+    })
+
+    const config = getConfig(plugin, {}, SSR_BUILD)
+    expect(config!.ssr!.noExternal).toEqual(['rails-vite-plugin'])
+  })
+
+  // --- Environment guards ---
+
+  it('throws in CI environment during serve', () => {
+    process.env.CI = 'true'
+    const plugin = jsbundling({ input: 'application.js' })
+
+    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+      'should not run the Vite dev server in CI',
+    )
+  })
+
+  it('throws in production environment during serve', () => {
+    process.env.RAILS_ENV = 'production'
+    const plugin = jsbundling({ input: 'application.js' })
+
+    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+      'should not run the Vite dev server in production',
+    )
+  })
+
+  it('allows build in CI', () => {
+    process.env.CI = 'true'
+    const plugin = jsbundling({ input: 'application.js' })
+
+    expect(() => getConfig(plugin)).not.toThrow()
+  })
+
+  it('allows build in production', () => {
+    process.env.RAILS_ENV = 'production'
+    const plugin = jsbundling({ input: 'application.js' })
+
+    expect(() => getConfig(plugin)).not.toThrow()
+  })
+
+  // --- Refresh paths ---
+
+  it('exports refreshPaths', () => {
+    expect(refreshPaths).toEqual([
+      'app/views/**/*.{erb,slim,haml}',
+      'app/helpers/**/*.rb',
+    ])
+  })
+
+  it('has the correct plugin name', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    expect(plugin.name).toBe('rails-vite-jsbundling')
+  })
+
+  it('enforces post', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    expect(plugin.enforce).toBe('post')
+  })
+
+  // --- Placeholder stubs ---
+
+  it('writes placeholder stubs during serve', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    // Clear mocks right before to isolate calls from plugin construction
+    vi.mocked(fs.mkdirSync).mockClear()
+    vi.mocked(fs.writeFileSync).mockClear()
+
+    getConfig(plugin, {}, SERVE)
+
+    // writePlaceholderStubs creates the directory and writes JS + CSS stubs
+    const mkdirCalls = vi.mocked(fs.mkdirSync).mock.calls
+    expect(mkdirCalls.some(([dir]) => dir === 'app/assets/builds')).toBe(true)
+
+    const writeCalls = vi.mocked(fs.writeFileSync).mock.calls
+    const jsStub = writeCalls.find(([path]) => path === 'app/assets/builds/application.js')
+    const cssStub = writeCalls.find(([path]) => path === 'app/assets/builds/application.css')
+    expect(jsStub).toBeDefined()
+    expect(String(jsStub![1])).toContain('placeholder')
+    expect(cssStub).toBeDefined()
+    expect(String(cssStub![1])).toContain('placeholder')
+  })
+
+  it('does not write placeholder stubs during build', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+
+    getConfig(plugin, {}, BUILD)
+
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  // --- writeBundle ---
+
+  it('copies entry JS and extracted CSS to assetPipelineDir', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+
+    const bundle = {
+      'application.js': { type: 'chunk', isEntry: true },
+      'application.css': { type: 'asset' },
+    }
+    callWriteBundle(plugin, bundle)
+
+    const copiedDests = vi.mocked(fs.copyFileSync).mock.calls.map(([, dest]) => dest)
+    expect(copiedDests).toContain(path.join('app/assets/builds', 'application.js'))
+    expect(copiedDests).toContain(path.join('app/assets/builds', 'application.css'))
+  })
+
+  it('does not copy shared chunk CSS to assetPipelineDir', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+
+    const bundle = {
+      'application.js': { type: 'chunk', isEntry: true },
+      'application.css': { type: 'asset' },
+      'vendor-abc123.css': { type: 'asset' },
+    }
+    callWriteBundle(plugin, bundle)
+
+    const copiedDests = vi.mocked(fs.copyFileSync).mock.calls.map(([, dest]) => dest)
+    expect(copiedDests).toContain(path.join('app/assets/builds', 'application.js'))
+    expect(copiedDests).toContain(path.join('app/assets/builds', 'application.css'))
+    expect(copiedDests).not.toContainEqual(expect.stringContaining('vendor'))
+  })
+
+  it('does not copy non-entry chunks to assetPipelineDir', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+
+    const bundle = {
+      'application.js': { type: 'chunk', isEntry: true },
+      'shared-chunk-abc.js': { type: 'chunk', isEntry: false },
+    }
+    callWriteBundle(plugin, bundle)
+
+    const copiedDests = vi.mocked(fs.copyFileSync).mock.calls.map(([, dest]) => dest)
+    expect(copiedDests).toHaveLength(1)
+    expect(copiedDests[0]).toContain('application.js')
+  })
+
+  it('removes CSS facade JS chunks from bundle', () => {
+    const plugin = jsbundling({
+      input: { app: 'application.js', styles: 'application.css' },
+    })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+
+    const bundle: Record<string, unknown> = {
+      'app.js': { type: 'chunk', isEntry: true },
+      '_css_styles.js': { type: 'chunk', isEntry: true },
+      'styles.css': { type: 'asset' },
+    }
+    ;(plugin.generateBundle as Function)({}, bundle)
+
+    expect(bundle).not.toHaveProperty('_css_styles.js')
+    expect(bundle).toHaveProperty('app.js')
+    expect(bundle).toHaveProperty('styles.css')
+  })
+
+  it('skips writeBundle for SSR builds', () => {
+    const plugin = jsbundling({ input: 'application.js', ssr: 'ssr.tsx' })
+    getConfig(plugin, {}, SSR_BUILD)
+    callConfigResolved(plugin, { build: { ssr: true, outDir: 'public/assets-ssr' } })
+
+    callWriteBundle(plugin, { 'ssr.js': { type: 'chunk', isEntry: true } })
+
+    expect(fs.copyFileSync).not.toHaveBeenCalled()
+  })
+
+  // --- configureServer: entrypoint watcher ---
+
+  it('does not match files in sibling directories with similar prefix', () => {
+    vi.useFakeTimers()
+
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    vi.mocked(fs.writeFileSync).mockClear()
+    vi.mocked(fs.rmSync).mockClear()
+
+    // File in a sibling directory that shares the entrypoints prefix
+    const epAbsDir = path.resolve('app/assets', 'entrypoints')
+    const siblingFile = `${epAbsDir}-v2/something.js`
+
+    server._emitWatcher('add', siblingFile)
+    vi.advanceTimersByTime(200)
+
+    // No stubs should have been regenerated for a sibling dir file
+    expect(fs.rmSync).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('matches files inside the entrypoints directory', () => {
+    vi.useFakeTimers()
+
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    vi.mocked(fs.writeFileSync).mockClear()
+    vi.mocked(fs.rmSync).mockClear()
+
+    const epAbsDir = path.resolve('app/assets', 'entrypoints')
+    const entrypointFile = `${epAbsDir}/new-entry.js`
+
+    server._emitWatcher('add', entrypointFile)
+    vi.advanceTimersByTime(200)
+
+    // Stubs should have been regenerated (rmSync for old stubs + writeFileSync for new)
+    expect(server.config.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('new entrypoint'),
+    )
+
+    vi.useRealTimers()
+  })
+
+  // --- configureServer: dev middleware ---
+
+  it('sets Content-Type header on dev server index page', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    const setupMiddleware = (plugin.configureServer as Function)(server)
+    setupMiddleware()
+
+    const middleware = vi.mocked(server.middlewares.use).mock.calls[0][0] as Function
+    const res = {
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    }
+
+    middleware({ url: '/index.html' }, res, vi.fn())
+
+    expect(res.statusCode).toBe(404)
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html')
+    expect(res.end).toHaveBeenCalled()
+  })
+
+  // --- configureServer: devMetaFile ---
+
+  it('creates parent directory for devMetaFile', () => {
+    const plugin = jsbundling({
+      input: 'application.js',
+      devMetaFile: 'some/nested/dir/meta.json',
+    })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    vi.mocked(fs.mkdirSync).mockClear()
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    const mkdirCalls = vi.mocked(fs.mkdirSync).mock.calls
+    expect(mkdirCalls).toContainEqual([
+      path.dirname('some/nested/dir/meta.json'),
+      { recursive: true },
+    ])
+  })
+
+  // --- writeDevStubs: CSS entries ---
+
+  it('writes empty CSS stubs for CSS entries', () => {
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    const writeCalls = vi.mocked(fs.writeFileSync).mock.calls
+    // Find the dev CSS stub (not placeholder — dev stubs are written after listening)
+    const cssStubs = writeCalls.filter(([p, content]) =>
+      String(p).endsWith('application.css') && String(content).includes('dev stub')
+    )
+    expect(cssStubs).toHaveLength(1)
+    // CSS stubs are empty — actual CSS is injected by @vite/client through JS imports
+    expect(String(cssStubs[0][1])).not.toContain('@import')
+  })
+
+  it('imports CSS entries in JS stubs for HMR', () => {
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    const writeCalls = vi.mocked(fs.writeFileSync).mock.calls
+    // Find the JS dev stub for application (not placeholder)
+    const jsStub = writeCalls.find(([p, content]) =>
+      String(p).endsWith('application.js') && String(content).includes('@vite/client')
+    )
+    expect(jsStub).toBeDefined()
+    // JS stub should import the CSS entry for HMR
+    expect(String(jsStub![1])).toContain('entrypoints/application.css')
+  })
+
+  // --- writeDevStubs: no duplicate tracking ---
+
+  it('does not track duplicate paths in writtenStubs', () => {
+    // Each stub path should appear only once in writtenStubs.
+    // We test this via the exit handler: it should not delete the same file twice.
+    const plugin = jsbundling({ sourceDir: 'app/assets' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    // Grab the exit handler function
+    const exitHandler = vi.mocked(bindExitHandler).mock.calls[0][0]
+
+    vi.mocked(fs.rmSync).mockClear()
+    exitHandler()
+
+    // Check no duplicate paths in rmSync calls
+    const removedPaths = vi.mocked(fs.rmSync).mock.calls.map(([p]) => p)
+    const uniquePaths = [...new Set(removedPaths)]
+    expect(removedPaths).toEqual(uniquePaths)
+  })
+})


### PR DESCRIPTION
This PR adds jsbundling mode — use Vite as a bundler with `jsbundling-rails` and Propshaft, no gem required.

If you're using [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) with Propshaft and want Vite as your bundler, you don't need the `rails_vite` gem — just the npm package:

```bash
npm install -D rails-vite-plugin vite
```

```typescript
// vite.config.ts
import { defineConfig } from 'vite';
import jsbundling from 'rails-vite-plugin/jsbundling';

export default defineConfig({
  plugins: [
    jsbundling(),
  ],
});
```
