### PR TITLE
[jsbundling] Fix SSR ?url imports

### DIFF
--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -96,6 +96,9 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
               outDir: userConfig.build?.outDir ?? ssrConfig.outDir,
               [bundlerOptionsKey]: {
                 input: userBundlerInput ?? ssrConfig.entry,
+                output: {
+                  assetFileNames: '[name][extname]',
+                },
               },
             },
           } : {}),


### PR DESCRIPTION
The jsbundling plugin's client build overrides `assetFileNames` to `[name][extname]`, but the SSR build didn't, leaving Vite's default `assets/[name]-[hash][extname]`. Combined with base: `/assets/`, `?url` imports in SSR resolved to `/assets/assets/image-abcd.webp` instead of `/assets/image.webp`.

This PR adds the matching `assetFileNames` override to the SSR build config.