### PR TITLE
Expose SSR output directory via gem config

### DIFF
--- a/lib/rails_vite/config.rb
+++ b/lib/rails_vite/config.rb
@@ -42,6 +42,10 @@ module RailsVite
       plugin_meta["url"]
     end
 
+    def ssr_output_dir
+      plugin_meta["ssrOutputDir"]
+    end
+
     def react_refresh?
       plugin_meta["reactRefresh"] == true
     end

--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -108,6 +108,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
       const outDir = resolvedConfig.build.outDir
       const meta: Record<string, unknown> = { sourceDir, buildDir: effectiveBuildDir }
       if (entrypointsDir) meta.entrypointsDir = entrypointsDir
+      if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
       fs.writeFileSync(path.join(outDir, 'rails-vite.json'), JSON.stringify(meta))
     },
 
@@ -124,6 +125,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
 
           const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, buildDir: effectiveBuildDir }
           if (entrypointsDir) meta.entrypointsDir = entrypointsDir
+          if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
           if (reactRefresh) meta.reactRefresh = true
           fs.writeFileSync(devMetaPath, JSON.stringify(meta))
 

--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -251,6 +251,7 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
           if (devMetaPath) {
             const meta: Record<string, unknown> = { url: devServerUrl, sourceDir }
             if (epDir) meta.entrypointsDir = epDir
+            if (ssrConfig) meta.ssrOutputDir = ssrConfig.outDir
             if (reactRefresh) meta.reactRefresh = true
             meta.jsbundling = true
             fs.mkdirSync(path.dirname(devMetaPath), { recursive: true })

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -111,4 +111,31 @@ class ConfigTest < Minitest::Test
       refute @config.react_refresh?
     end
   end
+
+  def test_ssr_output_dir_nil_by_default
+    assert_nil @config.ssr_output_dir
+  end
+
+  def test_ssr_output_dir_from_dev_meta
+    Dir.mktmpdir do |dir|
+      meta = File.join(dir, "rails-vite.json")
+      File.write(meta, '{"url":"http://localhost:5173","sourceDir":"app/javascript","ssrOutputDir":"ssr"}')
+      @config.dev_meta_path = Pathname.new(meta)
+
+      assert_equal "ssr", @config.ssr_output_dir
+    end
+  end
+
+  def test_ssr_output_dir_from_build_meta
+    Dir.mktmpdir do |dir|
+      vite_dir = File.join(dir, ".vite")
+      FileUtils.mkdir_p(vite_dir)
+      File.write(File.join(vite_dir, "manifest.json"), "{}")
+      File.write(File.join(vite_dir, "rails-vite.json"), '{"sourceDir":"app/javascript","ssrOutputDir":"ssr"}')
+
+      @config.manifest_path = Pathname.new(File.join(vite_dir, "manifest.json"))
+
+      assert_equal "ssr", @config.ssr_output_dir
+    end
+  end
 end


### PR DESCRIPTION
Read `ssrOutputDir` from `rails-vite.json` so Ruby can locate SSR bundles via `RailsVite.config.ssr_output_dir`.

- JS plugin writes `ssrOutputDir` into build and dev metadata when SSR is configured
- Ruby gem exposes `Config#ssr_output_dir` (nil when no SSR)