### PR TITLE
fix: avoid deleting dev metadata from another Vite process

### DIFF
--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -20,7 +20,7 @@ import { ensureCommandShouldRunInEnvironment } from './shared/env-guard.js'
 import { refreshPaths, resolveRefreshPaths } from './shared/refresh.js'
 import { readDevServerIndexHtml } from './shared/dev-server-page.js'
 import { resolveNoExternal } from './shared/ssr.js'
-import { bindExitHandler } from './shared/cleanup.js'
+import { bindExitHandler, removeOwnedFile } from './shared/cleanup.js'
 
 export type { InputOption }
 export { refreshPaths }
@@ -123,11 +123,15 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
         if (isAddressInfo(address)) {
           devServerUrl = resolveDevServerUrl(address, resolvedConfig)
 
-          const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, buildDir: effectiveBuildDir }
+          const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, buildDir: effectiveBuildDir, pid: process.pid }
           if (entrypointsDir) meta.entrypointsDir = entrypointsDir
           if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
           if (reactRefresh) meta.reactRefresh = true
           fs.writeFileSync(devMetaPath, JSON.stringify(meta))
+
+          bindExitHandler(() => {
+            removeOwnedFile(devMetaPath)
+          })
 
           setTimeout(() => {
             server.config.logger.info(
@@ -135,10 +139,6 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
             )
           }, 100)
         }
-      })
-
-      bindExitHandler(() => {
-        fs.rmSync(devMetaPath, { force: true })
       })
 
       // Watch view templates for full-page reload

--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -21,7 +21,7 @@ import { refreshPaths, resolveRefreshPaths } from './shared/refresh.js'
 import { cssExtensions } from './shared/css.js'
 import { readDevServerIndexHtml } from './shared/dev-server-page.js'
 import { resolveNoExternal } from './shared/ssr.js'
-import { bindExitHandler } from './shared/cleanup.js'
+import { bindExitHandler, removeOwnedFile } from './shared/cleanup.js'
 
 export type { InputOption }
 export { refreshPaths }
@@ -249,13 +249,17 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
 
           // Write dev meta file for progressive upgrade to the rails_vite gem
           if (devMetaPath) {
-            const meta: Record<string, unknown> = { url: devServerUrl, sourceDir }
+            const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, pid: process.pid }
             if (epDir) meta.entrypointsDir = epDir
             if (ssrConfig) meta.ssrOutputDir = ssrConfig.outDir
             if (reactRefresh) meta.reactRefresh = true
             meta.jsbundling = true
             fs.mkdirSync(path.dirname(devMetaPath), { recursive: true })
             fs.writeFileSync(devMetaPath, JSON.stringify(meta))
+
+            bindExitHandler(() => {
+              removeOwnedFile(devMetaPath)
+            })
           }
 
           // Watch entrypoints dir for new/removed files and regenerate stubs
@@ -288,9 +292,6 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
           fs.rmSync(stub, { force: true })
         }
         writtenStubs.length = 0
-        if (devMetaPath) {
-          fs.rmSync(devMetaPath, { force: true })
-        }
       })
 
       // Watch view templates for full-page reload

--- a/packages/rails-vite-plugin/src/shared/cleanup.ts
+++ b/packages/rails-vite-plugin/src/shared/cleanup.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+
 let exitHandlersBound = false
 
 /**
@@ -12,5 +14,19 @@ export function bindExitHandler(cleanupFn: () => void): void {
     process.on('SIGTERM', () => process.exit())
     process.on('SIGHUP', () => process.exit())
     exitHandlersBound = true
+  }
+}
+
+export function removeOwnedFile(filePath: string, pid = process.pid): void {
+  let ownerPid: unknown
+
+  try {
+    ownerPid = JSON.parse(fs.readFileSync(filePath, 'utf8')).pid
+  } catch {
+    return
+  }
+
+  if (ownerPid === pid) {
+    fs.rmSync(filePath, { force: true })
   }
 }

--- a/packages/rails-vite-plugin/tests/cleanup.test.ts
+++ b/packages/rails-vite-plugin/tests/cleanup.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import { removeOwnedFile } from '../src/shared/cleanup'
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    default: {
+      ...actual,
+      readFileSync: vi.fn(),
+      rmSync: vi.fn(),
+    },
+  }
+})
+
+describe('cleanup helpers', () => {
+  afterEach(() => {
+    vi.mocked(fs.readFileSync).mockReset()
+    vi.mocked(fs.rmSync).mockReset()
+  })
+
+  it('removes a file owned by the current process', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ pid: 123 }))
+
+    removeOwnedFile('tmp/rails-vite.json', 123)
+
+    expect(fs.rmSync).toHaveBeenCalledWith('tmp/rails-vite.json', { force: true })
+  })
+
+  it('keeps a file owned by another process', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ pid: 456 }))
+
+    removeOwnedFile('tmp/rails-vite.json', 123)
+
+    expect(fs.rmSync).not.toHaveBeenCalled()
+  })
+
+  it('keeps files without readable ownership metadata', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue('{')
+
+    removeOwnedFile('tmp/rails-vite.json', 123)
+
+    expect(fs.rmSync).not.toHaveBeenCalled()
+  })
+})

--- a/packages/rails-vite-plugin/tests/index.test.ts
+++ b/packages/rails-vite-plugin/tests/index.test.ts
@@ -3,14 +3,74 @@ import fs from 'fs'
 import path from 'path'
 import type { ConfigEnv, Plugin, UserConfig } from 'vite'
 import rails, { refreshPaths } from '../src'
+import { bindExitHandler } from '../src/shared/cleanup'
 
 const BUILD: ConfigEnv = { command: 'build', mode: 'production' }
 const SSR_BUILD: ConfigEnv = { command: 'build', mode: 'production', isSsrBuild: true }
 const SERVE: ConfigEnv = { command: 'serve', mode: 'development' }
+type Callback = (...args: unknown[]) => void
 
 function getConfig(plugin: Plugin, userConfig: UserConfig = {}, env: ConfigEnv = BUILD): UserConfig {
   return (plugin.config as (config: UserConfig, env: ConfigEnv) => UserConfig)(userConfig, env)
 }
+
+function callConfigureServer(plugin: Plugin, server: MockServer) {
+  return (plugin.configureServer as unknown as (server: MockServer) => unknown)(server)
+}
+
+function callConfigResolved(plugin: Plugin, overrides: Record<string, unknown> = {}) {
+  ;(plugin.configResolved as unknown as (config: Record<string, unknown>) => void)({
+    build: { ssr: false, outDir: 'public/vite' },
+    plugins: [],
+    server: { hmr: false, https: false, host: 'localhost' },
+    ...overrides,
+  })
+}
+
+interface MockServer {
+  httpServer?: {
+    once: (event: string, cb: Callback) => void
+    address: () => { address: string; port: number; family: string }
+  }
+  watcher: {
+    add: ReturnType<typeof vi.fn>
+    on: (event: string, cb: Callback) => void
+  }
+  config: { logger: { info: ReturnType<typeof vi.fn> } }
+  hot: { send: ReturnType<typeof vi.fn> }
+  middlewares: { use: ReturnType<typeof vi.fn> }
+  _emit: (event: string, ...args: unknown[]) => void
+}
+
+function createMockServer({ httpServer = true } = {}): MockServer {
+  const eventListeners: Record<string, Callback[]> = {}
+
+  return {
+    httpServer: httpServer
+      ? {
+          once(event: string, cb: Callback) {
+            eventListeners[event] = eventListeners[event] || []
+            eventListeners[event].push(cb)
+          },
+          address: () => ({ address: '127.0.0.1', port: 5173, family: 'IPv4' }),
+        }
+      : undefined,
+    watcher: {
+      add: vi.fn(),
+      on: vi.fn(),
+    },
+    config: { logger: { info: vi.fn() } },
+    hot: { send: vi.fn() },
+    middlewares: { use: vi.fn() },
+    _emit(event: string, ...args: unknown[]) {
+      for (const cb of eventListeners[event] || []) cb(...args)
+    },
+  }
+}
+
+vi.mock('../src/shared/cleanup.js', () => ({
+  bindExitHandler: vi.fn(),
+}))
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs')
@@ -39,6 +99,9 @@ vi.mock('fs', async () => {
         }
         return actual.readdirSync(dir, options as Parameters<typeof actual.readdirSync>[1])
       },
+      readFileSync: vi.fn((filePath: string, encoding?: string) => actual.readFileSync(filePath, encoding as BufferEncoding)),
+      writeFileSync: vi.fn(),
+      rmSync: vi.fn(),
     },
   }
 })
@@ -47,6 +110,10 @@ describe('rails-vite-plugin', () => {
   afterEach(() => {
     delete process.env.CI
     delete process.env.RAILS_ENV
+    vi.mocked(fs.readFileSync).mockClear()
+    vi.mocked(fs.writeFileSync).mockClear()
+    vi.mocked(fs.rmSync).mockClear()
+    vi.mocked(bindExitHandler).mockClear()
   })
 
   // --- Input handling ---
@@ -383,6 +450,37 @@ describe('rails-vite-plugin', () => {
     const plugin = rails({ input: 'application.js' })
 
     expect(() => getConfig(plugin)).not.toThrow()
+  })
+
+  // --- configureServer: devMetaFile cleanup ---
+
+  it('does not register devMetaFile cleanup without an HTTP server', () => {
+    const plugin = rails({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    callConfigureServer(plugin, createMockServer({ httpServer: false }))
+
+    expect(bindExitHandler).not.toHaveBeenCalled()
+  })
+
+  it('writes pid to devMetaFile and registers cleanup after listening', () => {
+    const plugin = rails({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    callConfigureServer(plugin, server)
+    server._emit('listening')
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('tmp', 'rails-vite.json'))
+    expect(metaWrite).toBeDefined()
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({
+      url: 'http://localhost:5173',
+      sourceDir: 'app/javascript',
+      pid: process.pid,
+    })
+    expect(bindExitHandler).toHaveBeenCalledOnce()
   })
 
   // --- Refresh paths ---

--- a/packages/rails-vite-plugin/tests/jsbundling.test.ts
+++ b/packages/rails-vite-plugin/tests/jsbundling.test.ts
@@ -22,6 +22,10 @@ function callConfigResolved(plugin: Plugin, overrides: Record<string, unknown> =
   })
 }
 
+function callConfigureServer(plugin: Plugin, server: unknown) {
+  return (plugin.configureServer as unknown as (server: unknown) => unknown)(server)
+}
+
 function callWriteBundle(plugin: Plugin, bundle: Record<string, unknown>) {
   ;(plugin.writeBundle as Function)({}, bundle)
 }
@@ -125,12 +129,12 @@ vi.mock('fs', async () => {
         }
         return actual.readdirSync(dir, options as Parameters<typeof actual.readdirSync>[1])
       },
-      readFileSync: (filePath: string, encoding?: string) => {
+      readFileSync: vi.fn((filePath: string, encoding?: string) => {
         if (typeof filePath === 'string' && filePath.includes('dev-server-index.html')) {
           return '<html><body>Vite Dev Server</body></html>'
         }
         return actual.readFileSync(filePath, encoding as BufferEncoding)
-      },
+      }),
       mkdirSync: vi.fn(),
       writeFileSync: vi.fn(),
       copyFileSync: vi.fn(),
@@ -144,6 +148,7 @@ describe('rails-vite-plugin/jsbundling', () => {
     delete process.env.CI
     delete process.env.RAILS_ENV
     vi.mocked(fs.mkdirSync).mockClear()
+    vi.mocked(fs.readFileSync).mockClear()
     vi.mocked(fs.writeFileSync).mockClear()
     vi.mocked(fs.copyFileSync).mockClear()
     vi.mocked(fs.rmSync).mockClear()
@@ -609,7 +614,7 @@ describe('rails-vite-plugin/jsbundling', () => {
     vi.mocked(fs.writeFileSync).mockClear()
 
     const server = createMockServer()
-    ;(plugin.configureServer as Function)(server)
+    callConfigureServer(plugin, server)
 
     // writePlaceholderStubs creates the directory and writes JS + CSS stubs
     const mkdirCalls = vi.mocked(fs.mkdirSync).mock.calls
@@ -734,7 +739,7 @@ describe('rails-vite-plugin/jsbundling', () => {
     callConfigResolved(plugin)
 
     const server = createMockServer()
-    ;(plugin.configureServer as Function)(server)
+    callConfigureServer(plugin, server)
     server._emit('listening')
 
     vi.mocked(fs.writeFileSync).mockClear()
@@ -827,6 +832,42 @@ describe('rails-vite-plugin/jsbundling', () => {
       path.dirname('some/nested/dir/meta.json'),
       { recursive: true },
     ])
+  })
+
+  it('does not remove devMetaFile from cleanup when no HTTP server wrote it', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = { ...createMockServer(), httpServer: undefined }
+    ;(plugin.configureServer as Function)(server)
+
+    const exitHandler = vi.mocked(bindExitHandler).mock.calls[0][0]
+
+    vi.mocked(fs.rmSync).mockClear()
+    exitHandler()
+
+    expect(fs.rmSync).not.toHaveBeenCalledWith(path.join('tmp', 'rails-vite.json'), { force: true })
+  })
+
+  it('writes pid to devMetaFile and registers owned cleanup after listening', () => {
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('tmp', 'rails-vite.json'))
+    expect(metaWrite).toBeDefined()
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({
+      url: 'http://localhost:5173',
+      sourceDir: 'app/javascript',
+      pid: process.pid,
+      jsbundling: true,
+    })
+    expect(bindExitHandler).toHaveBeenCalledTimes(2)
   })
 
   // --- writeDevStubs: CSS entries ---


### PR DESCRIPTION
## Problem

`tmp/rails-vite.json` is removed unconditionally when a Vite dev server exits.

If another Vite-backed process has already started and written fresh metadata, the older process can still delete that newer file on the way out. Rails can then briefly lose track of the active dev server.

Before:

1. Process A writes `tmp/rails-vite.json`.
2. Process B starts later and writes fresh metadata to the same file.
3. Process A exits and removes `tmp/rails-vite.json`.
4. Rails no longer sees Process B until the file is written again.

After:

1. Process B writes fresh metadata with its PID.
2. Process A exits, sees the file is no longer owned by Process A, and leaves it in place.

```json
// before
{"url":"http://localhost:5173","sourceDir":"app/javascript","buildDir":"vite"}

// after
{"url":"http://localhost:5173","sourceDir":"app/javascript","buildDir":"vite","pid":12345}
```


## Solution

This records the writer PID in dev metadata and uses it as a lightweight ownership check during cleanup. If the metadata file now belongs to another process, the exiting process leaves it alone.

Cleanup registration now also happens only after the metadata file is written, so embedded/no-HTTP-server cases do not register cleanup for a file they never created.

In this PR:

- Add `pid` to dev metadata written by `rails()` and `jsbundling()`.
- Add shared `removeOwnedFile()` cleanup helper.
- Only remove dev metadata when its recorded PID matches the exiting process.
- Keep jsbundling stub cleanup behavior unchanged.
- Add Vitest coverage for owned cleanup and both plugin modes.

---

Resolves https://github.com/skryukov/rails_vite/issues/23
