### PR TITLE
fix: allow Vite config resolution in CI without weakening the dev-server guard

### DIFF
--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -54,15 +54,14 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
   let reactRefresh = false
   let devServerUrl: string | null = null
   let effectiveBuildDir: string
+  let devServerEnv: Record<string, string> = {}
 
   return {
     name: 'rails-vite',
     enforce: 'post',
 
     config(userConfig: UserConfig, { command, mode, isSsrBuild }: ConfigEnv): UserConfig {
-      const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
-
-      ensureCommandShouldRunInEnvironment(command, env, 'rails-vite-plugin')
+      devServerEnv = loadEnv(mode, userConfig.envDir || process.cwd(), '')
 
       // @ts-expect-error -- `this.meta.rolldownVersion` exists in Vite 8+
       const bundlerOptionsKey = resolveBundlerOptionsKey(this.meta)
@@ -117,6 +116,8 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
     },
 
     configureServer(server) {
+      ensureCommandShouldRunInEnvironment('serve', devServerEnv, 'rails-vite-plugin')
+
       server.httpServer?.once('listening', () => {
         const address = server.httpServer?.address()
 

--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -67,6 +67,7 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
   let resolvedConfig: ResolvedConfig
   let reactRefresh = false
   let devServerUrl: string | null = null
+  let devServerEnv: Record<string, string> = {}
 
   // Track stubs written in dev so we can clean them up
   const writtenStubs: string[] = []
@@ -76,9 +77,7 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
     enforce: 'post',
 
     config(userConfig: UserConfig, { command, mode, isSsrBuild }: ConfigEnv): UserConfig {
-      const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
-
-      ensureCommandShouldRunInEnvironment(command, env, 'rails-vite-plugin/jsbundling')
+      devServerEnv = loadEnv(mode, userConfig.envDir || process.cwd(), '')
 
       // @ts-expect-error -- `this.meta.rolldownVersion` exists in Vite 8+
       const bundlerOptionsKey = resolveBundlerOptionsKey(this.meta)
@@ -206,6 +205,8 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
     },
 
     configureServer(server) {
+      ensureCommandShouldRunInEnvironment('serve', devServerEnv, 'rails-vite-plugin/jsbundling')
+
       let syncTimer: ReturnType<typeof setTimeout> | null = null
 
       // Re-discover entries from the entrypoints dir and regenerate all stubs.

--- a/packages/rails-vite-plugin/tests/environment-guard.test.ts
+++ b/packages/rails-vite-plugin/tests/environment-guard.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createServer, resolveConfig, type InlineConfig, type Plugin } from 'vite'
+import rails from '../src'
+import jsbundling from '../src/jsbundling'
+
+function viteConfig(plugin: Plugin): InlineConfig {
+  return {
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [plugin],
+  }
+}
+
+describe('environment guards', () => {
+  afterEach(() => {
+    delete process.env.CI
+    delete process.env.RAILS_ENV
+  })
+
+  it('allows rails() config resolution in CI', async () => {
+    process.env.CI = 'true'
+
+    await expect(
+      resolveConfig(viteConfig(rails({ input: 'application.js' })), 'serve', 'development'),
+    ).resolves.toBeDefined()
+  })
+
+  it('rejects rails() dev server startup in CI', async () => {
+    process.env.CI = 'true'
+
+    await expect(
+      createServer(viteConfig(rails({ input: 'application.js' }))),
+    ).rejects.toThrowError('should not run the Vite dev server in CI')
+  })
+
+  it('allows jsbundling() config resolution in CI', async () => {
+    process.env.CI = 'true'
+
+    await expect(
+      resolveConfig(viteConfig(jsbundling({ input: 'application.js' })), 'serve', 'development'),
+    ).resolves.toBeDefined()
+  })
+
+  it('rejects jsbundling() dev server startup in CI', async () => {
+    process.env.CI = 'true'
+
+    await expect(
+      createServer(viteConfig(jsbundling({ input: 'application.js' }))),
+    ).rejects.toThrowError('should not run the Vite dev server in CI')
+  })
+})

--- a/packages/rails-vite-plugin/tests/index.test.ts
+++ b/packages/rails-vite-plugin/tests/index.test.ts
@@ -420,20 +420,36 @@ describe('rails-vite-plugin', () => {
 
   // --- Environment guards ---
 
-  it('throws in CI environment during serve', () => {
+  it('allows config resolution in CI environment during serve', () => {
     process.env.CI = 'true'
     const plugin = rails({ input: 'application.js' })
 
-    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+    expect(() => getConfig(plugin, {}, SERVE)).not.toThrow()
+  })
+
+  it('throws when configuring dev server in CI environment', () => {
+    process.env.CI = 'true'
+    const plugin = rails({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+
+    expect(() => (plugin.configureServer as Function)({})).toThrowError(
       'should not run the Vite dev server in CI',
     )
   })
 
-  it('throws in production environment during serve', () => {
+  it('allows config resolution in production environment during serve', () => {
     process.env.RAILS_ENV = 'production'
     const plugin = rails({ input: 'application.js' })
 
-    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+    expect(() => getConfig(plugin, {}, SERVE)).not.toThrow()
+  })
+
+  it('throws when configuring dev server in production environment', () => {
+    process.env.RAILS_ENV = 'production'
+    const plugin = rails({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+
+    expect(() => (plugin.configureServer as Function)({})).toThrowError(
       'should not run the Vite dev server in production',
     )
   })

--- a/packages/rails-vite-plugin/tests/jsbundling.test.ts
+++ b/packages/rails-vite-plugin/tests/jsbundling.test.ts
@@ -550,20 +550,36 @@ describe('rails-vite-plugin/jsbundling', () => {
 
   // --- Environment guards ---
 
-  it('throws in CI environment during serve', () => {
+  it('allows config resolution in CI environment during serve', () => {
     process.env.CI = 'true'
     const plugin = jsbundling({ input: 'application.js' })
 
-    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+    expect(() => getConfig(plugin, {}, SERVE)).not.toThrow()
+  })
+
+  it('throws when configuring dev server in CI environment', () => {
+    process.env.CI = 'true'
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+
+    expect(() => (plugin.configureServer as Function)({})).toThrowError(
       'should not run the Vite dev server in CI',
     )
   })
 
-  it('throws in production environment during serve', () => {
+  it('allows config resolution in production environment during serve', () => {
     process.env.RAILS_ENV = 'production'
     const plugin = jsbundling({ input: 'application.js' })
 
-    expect(() => getConfig(plugin, {}, SERVE)).toThrowError(
+    expect(() => getConfig(plugin, {}, SERVE)).not.toThrow()
+  })
+
+  it('throws when configuring dev server in production environment', () => {
+    process.env.RAILS_ENV = 'production'
+    const plugin = jsbundling({ input: 'application.js' })
+    getConfig(plugin, {}, SERVE)
+
+    expect(() => (plugin.configureServer as Function)({})).toThrowError(
       'should not run the Vite dev server in production',
     )
   })


### PR DESCRIPTION
This moves the CI/production dev-server guard from Vite's `config` hook to `configureServer` for both `rails()` and `jsbundling()`.

The goal is to stop blocking tools that only need to read `vite.config.*`, while still preventing the Vite dev server from running in CI or with `RAILS_ENV=production`.

## Motivation

Svelte language-tools now reads Svelte options from `vite.config.*` when available: https://github.com/sveltejs/language-tools/pull/3031

That means tools like `svelte-check` can ask Vite to resolve config in `serve` mode without actually starting a dev server. Previously, we raised during config resolution, so those tools could fail even though they were not trying to run Vite.

Before this change:

- `resolveConfig(..., "serve")` could fail under `CI=true`.
- `createServer(...)` failed under `CI=true`.

After this change:

- `resolveConfig(..., "serve")` succeeds under `CI=true`.
- `createServer(...)` still fails under `CI=true`.

## Backward Compatibility

The existing safety behavior is preserved:

- `vite build` is unchanged.
- Starting the dev server in CI still fails.
- Starting the dev server with `RAILS_ENV=production` still fails.
- Guard messages are unchanged.

The only intentional behavior change is that config resolution in `serve` mode no longer fails just because `CI` or `RAILS_ENV=production` is set.

The guard is moved to the dev-server setup hook, not removed so I think the risk is low.
