### PR TITLE
feat: cache auto-build freshness across Rails restarts

### DIFF
--- a/lib/rails_vite/auto_build.rb
+++ b/lib/rails_vite/auto_build.rb
@@ -1,17 +1,37 @@
+require "digest"
 require "find"
+require "json"
+require "pathname"
+require "time"
+
+require_relative "version"
 
 module RailsVite
   class AutoBuild
     NEVER = Time.at(0).freeze
     SOURCE_CHECK_INTERVAL = 2 # seconds
+    CONFIG_FILES = %w[
+      bun.lock
+      bun.lockb
+      package-lock.json
+      package.json
+      pnpm-lock.yaml
+      tsconfig.json
+      vite.config.cjs
+      vite.config.cts
+      vite.config.js
+      vite.config.mjs
+      vite.config.mts
+      vite.config.ts
+      yarn.lock
+    ].freeze
 
     def initialize(app, config)
       @app = app
       @config = config
       @mutex = Mutex.new
-      @last_build_at = NEVER
-      @cached_source_mtime = nil
-      @source_mtime_checked_at = nil
+      @cached_inputs = nil
+      @inputs_checked_at = nil
     end
 
     def call(env)
@@ -25,41 +45,136 @@ module RailsVite
       @mutex.synchronize do
         return unless stale?
 
-        Rails.logger.error("rails-vite: build failed") unless system(RailsVite::Tasks.build_command)
-        @last_build_at = Time.now
-        @cached_source_mtime = nil
-        @source_mtime_checked_at = nil
+        if run_build
+          write_metadata(current_digest)
+        else
+          Rails.logger.error("rails-vite: build failed")
+        end
+
+        clear_inputs_cache
       end
     end
 
     def stale?
-      !File.exist?(@config.manifest_path) ||
-        latest_source_mtime > @last_build_at
-    end
+      return true unless File.exist?(@config.manifest_path)
 
-    def latest_source_mtime
-      now = Time.now
-      if @cached_source_mtime && @source_mtime_checked_at && (now - @source_mtime_checked_at) < SOURCE_CHECK_INTERVAL
-        return @cached_source_mtime
+      digest = current_digest
+      return true unless digest
+
+      metadata = read_metadata
+      if metadata.any?
+        return !(metadata["success"] == true &&
+          metadata["digest"] == digest &&
+          metadata["version"] == RailsVite::VERSION)
       end
 
-      @source_mtime_checked_at = now
-      @cached_source_mtime = compute_latest_source_mtime
+      latest_input_mtime > File.mtime(@config.manifest_path)
     end
 
-    def compute_latest_source_mtime
-      latest = NEVER
+    def run_build
+      system(RailsVite::Tasks.build_command)
+    end
+
+    def write_metadata(digest)
+      return unless digest
+      return unless File.exist?(@config.manifest_path)
+
+      @config.auto_build_cache_path.write(JSON.generate({
+        success: true,
+        digest: digest,
+        version: RailsVite::VERSION,
+        builtAt: Time.now.utc.iso8601
+      }))
+    end
+
+    def read_metadata
+      JSON.parse(@config.auto_build_cache_path.read)
+    rescue Errno::ENOENT, JSON::ParserError
+      {}
+    end
+
+    def current_digest
+      inputs = current_inputs
+      return nil if inputs.nil?
+
+      digest = Digest::SHA256.new
+      inputs.each do |path|
+        digest << path
+        digest << "\0"
+        digest << File.binread(path)
+        digest << "\0"
+      end
+      digest.hexdigest
+    end
+
+    def latest_input_mtime
+      inputs = current_inputs
+      return Time.now if inputs.nil?
+
+      inputs.map { |path| File.mtime(path) }.max || NEVER
+    end
+
+    def current_inputs
+      now = Time.now
+      if @cached_inputs && @inputs_checked_at && (now - @inputs_checked_at) < SOURCE_CHECK_INTERVAL
+        return @cached_inputs
+      end
+
+      @inputs_checked_at = now
+      @cached_inputs = compute_inputs
+    end
+
+    def compute_inputs
+      paths = []
       source_path = Rails.root.join(@config.source_dir).to_s
 
-      Find.find(source_path) do |path|
-        next unless File.file?(path)
-        mtime = File.mtime(path)
-        latest = mtime if mtime > latest
+      source_dir_missing = !File.directory?(source_path)
+      unless source_dir_missing
+        Find.find(source_path) do |path|
+          next unless File.file?(path)
+          paths << path
+        end
       end
 
-      latest
-    rescue Errno::ENOENT
-      Time.now # source dir missing — trigger build to surface the error
+      build_input_missing = @config.build_inputs.any? do |path|
+        !append_input_path(paths, path)
+      end
+
+      CONFIG_FILES.each do |path|
+        full_path = Rails.root.join(path).to_s
+        paths << full_path if File.file?(full_path)
+      end
+
+      return nil if build_input_missing
+      return nil if source_dir_missing && @config.build_inputs.empty?
+
+      paths.uniq.sort
+    end
+
+    def clear_inputs_cache
+      @cached_inputs = nil
+      @inputs_checked_at = nil
+    end
+
+    def append_input_path(paths, path)
+      full_path = expand_input_path(path)
+      if File.directory?(full_path)
+        Find.find(full_path) do |nested_path|
+          next unless File.file?(nested_path)
+          paths << nested_path
+        end
+        true
+      elsif File.file?(full_path)
+        paths << full_path
+        true
+      else
+        false
+      end
+    end
+
+    def expand_input_path(path)
+      pathname = Pathname.new(path)
+      pathname.absolute? ? pathname.to_s : Rails.root.join(path).to_s
     end
   end
 end

--- a/lib/rails_vite/config.rb
+++ b/lib/rails_vite/config.rb
@@ -16,6 +16,10 @@ module RailsVite
       @manifest_path || Rails.root.join("public", build_dir, "manifest.json")
     end
 
+    def auto_build_cache_path
+      manifest_path.dirname.join("rails-vite-auto-build.json")
+    end
+
     def asset_prefix
       @asset_prefix || "/#{build_dir}"
     end
@@ -26,6 +30,10 @@ module RailsVite
 
     def entrypoints_dir
       plugin_meta["entrypointsDir"]
+    end
+
+    def build_inputs
+      Array(plugin_meta["buildInputs"]).select { |input| input.is_a?(String) }
     end
 
     def auto_build?

--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -15,7 +15,7 @@ import { ORIGIN_PLACEHOLDER } from './shared/types.js'
 import { resolveInput, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint } from './shared/entries.js'
 import { resolveAlias } from './shared/alias.js'
 import { resolveDevServerUrl, isAddressInfo, replaceOriginPlaceholder } from './shared/dev-server.js'
-import { resolveBundlerOptionsKey, getUserBundlerInput } from './shared/bundler-compat.js'
+import { resolveBundlerOptionsKey, getUserBundlerInput, getResolvedBundlerInput, normalizeBundlerInput } from './shared/bundler-compat.js'
 import { ensureCommandShouldRunInEnvironment } from './shared/env-guard.js'
 import { refreshPaths, resolveRefreshPaths } from './shared/refresh.js'
 import { readDevServerIndexHtml } from './shared/dev-server-page.js'
@@ -107,6 +107,8 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
 
       const outDir = resolvedConfig.build.outDir
       const meta: Record<string, unknown> = { sourceDir, buildDir: effectiveBuildDir }
+      const buildInputs = normalizeBundlerInput(getResolvedBundlerInput(resolvedConfig.build))
+      if (buildInputs.length) meta.buildInputs = buildInputs
       if (entrypointsDir) meta.entrypointsDir = entrypointsDir
       if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
       fs.writeFileSync(path.join(outDir, 'rails-vite.json'), JSON.stringify(meta))

--- a/packages/rails-vite-plugin/src/shared/bundler-compat.ts
+++ b/packages/rails-vite-plugin/src/shared/bundler-compat.ts
@@ -10,3 +10,17 @@ export function getUserBundlerInput(userConfig: UserConfig): unknown {
   // @ts-expect-error -- `rolldownOptions` exists in Vite 8+ only
   return userConfig.build?.rolldownOptions?.input ?? userConfig.build?.rollupOptions?.input
 }
+
+export function getResolvedBundlerInput(buildConfig: { rollupOptions?: { input?: unknown } }): unknown {
+  const config = buildConfig as { rolldownOptions?: { input?: unknown }, rollupOptions?: { input?: unknown } }
+  return config.rolldownOptions?.input ?? config.rollupOptions?.input
+}
+
+export function normalizeBundlerInput(input: unknown): string[] {
+  if (typeof input === 'string') return [input]
+  if (Array.isArray(input)) return input.filter((entry): entry is string => typeof entry === 'string')
+  if (input && typeof input === 'object') {
+    return Object.values(input).filter((entry): entry is string => typeof entry === 'string')
+  }
+  return []
+}

--- a/packages/rails-vite-plugin/tests/index.test.ts
+++ b/packages/rails-vite-plugin/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import fs from 'fs'
 import path from 'path'
 import type { ConfigEnv, Plugin, UserConfig } from 'vite'
@@ -10,6 +10,18 @@ const SERVE: ConfigEnv = { command: 'serve', mode: 'development' }
 
 function getConfig(plugin: Plugin, userConfig: UserConfig = {}, env: ConfigEnv = BUILD): UserConfig {
   return (plugin.config as (config: UserConfig, env: ConfigEnv) => UserConfig)(userConfig, env)
+}
+
+function callConfigResolved(plugin: Plugin, overrides: Record<string, unknown> = {}) {
+  ;(plugin.configResolved as Function)({
+    build: { ssr: false, outDir: 'public/vite', rollupOptions: { input: 'app/javascript/application.js' } },
+    plugins: [],
+    ...overrides,
+  })
+}
+
+function callWriteBundle(plugin: Plugin) {
+  ;(plugin.writeBundle as Function)()
 }
 
 vi.mock('fs', async () => {
@@ -39,11 +51,16 @@ vi.mock('fs', async () => {
         }
         return actual.readdirSync(dir, options as Parameters<typeof actual.readdirSync>[1])
       },
+      writeFileSync: vi.fn(),
     },
   }
 })
 
 describe('rails-vite-plugin', () => {
+  beforeEach(() => {
+    vi.mocked(fs.writeFileSync).mockClear()
+  })
+
   afterEach(() => {
     delete process.env.CI
     delete process.env.RAILS_ENV
@@ -211,6 +228,52 @@ describe('rails-vite-plugin', () => {
 
     const config = getConfig(plugin, { build: { rollupOptions: { input: 'custom/entry.js' } } })
     expect(config!.build!.rollupOptions!.input).toBe('custom/entry.js')
+  })
+
+  it('writes resolved build inputs to build metadata', () => {
+    const plugin = rails({ input: ['application.js', '/absolute/admin.js'] })
+    getConfig(plugin)
+    callConfigResolved(plugin, {
+      build: {
+        ssr: false,
+        outDir: 'public/vite',
+        rollupOptions: { input: ['app/javascript/application.js', '/absolute/admin.js'] },
+      },
+    })
+
+    callWriteBundle(plugin)
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join('public/vite', 'rails-vite.json'),
+      JSON.stringify({
+        sourceDir: 'app/javascript',
+        buildDir: 'vite',
+        buildInputs: ['app/javascript/application.js', '/absolute/admin.js'],
+      }),
+    )
+  })
+
+  it('writes user rollupOptions.input to build metadata', () => {
+    const plugin = rails({ input: 'application.js' })
+    getConfig(plugin, { build: { rollupOptions: { input: 'custom/entry.js' } } })
+    callConfigResolved(plugin, {
+      build: {
+        ssr: false,
+        outDir: 'public/vite',
+        rollupOptions: { input: 'custom/entry.js' },
+      },
+    })
+
+    callWriteBundle(plugin)
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join('public/vite', 'rails-vite.json'),
+      JSON.stringify({
+        sourceDir: 'app/javascript',
+        buildDir: 'vite',
+        buildInputs: ['custom/entry.js'],
+      }),
+    )
   })
 
   it('respects user server.cors config', () => {

--- a/test/auto_build_test.rb
+++ b/test/auto_build_test.rb
@@ -22,78 +22,256 @@ class AutoBuildTest < Minitest::Test
   end
 
   def test_builds_when_manifest_missing
-    built = false
-    stub_build(-> { built = true }) do
-      middleware = RailsVite::AutoBuild.new(@app, @config)
-      middleware.call({})
-    end
+    with_root do
+      built = false
+      stub_build(->(*) { built = true }) do
+        middleware = RailsVite::AutoBuild.new(@app, @config)
+        middleware.call({})
+      end
 
-    assert built
+      assert built
+    end
   end
 
-  def test_builds_when_sources_newer_than_last_build
-    File.write(@manifest_path, "{}")
+  def test_skips_build_when_manifest_is_newer_than_sources
+    write_manifest(mtime: Time.now)
+    FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now - 10)
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
+    with_root do
+      built = false
+      stub_build(->(*) { built = true }) do
+        middleware = RailsVite::AutoBuild.new(@app, @config)
+        middleware.call({})
+      end
 
-    # Simulate a previous build
-    middleware.instance_variable_set(:@last_build_at, Time.now - 10)
+      refute built
+    end
+  end
+
+  def test_builds_when_sources_newer_than_manifest
+    write_manifest(mtime: Time.now - 10)
     FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now)
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
-    end
+    with_root do
+      built = false
+      stub_build(->(*) { built = true }) do
+        middleware = RailsVite::AutoBuild.new(@app, @config)
+        middleware.call({})
+      end
 
-    assert built
+      assert built
+    end
   end
 
-  def test_skips_build_when_manifest_fresh
-    File.write(@manifest_path, "{}")
+  def test_skips_build_across_middleware_instances_when_inputs_unchanged
+    with_root do
+      first_build = false
+      stub_build(->(*) {
+        first_build = true
+        write_manifest
+      }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.now + 10)
+      second_build = false
+      stub_build(->(*) { second_build = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
+      assert first_build
+      refute second_build
     end
-
-    refute built
   end
 
-  def test_missing_source_dir_triggers_build
+  def test_builds_when_sources_change_after_cached_build
+    with_root do
+      stub_build(->(*) { write_manifest }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      File.write(File.join(@source_dir, "app.js"), "console.log('changed')")
+
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_builds_when_source_digest_changes_with_old_mtime
+    with_root do
+      stub_build(->(*) { write_manifest }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      source_file = File.join(@source_dir, "app.js")
+      File.write(source_file, "console.log('changed')")
+      FileUtils.touch(source_file, mtime: File.mtime(@manifest_path) - 10)
+
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_builds_when_config_changes_after_cached_build
+    with_root do
+      stub_build(->(*) { write_manifest }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      File.write(File.join(@dir, "vite.config.ts"), "export default {}")
+
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_builds_when_build_input_changes_after_cached_build
+    build_input = File.join(@dir, "frontend/custom.js")
+    FileUtils.mkdir_p(File.dirname(build_input))
+    File.write(build_input, "console.log('custom')")
+    write_build_meta(build_inputs: ["frontend/custom.js"])
+
+    with_root do
+      stub_build(->(*) { write_manifest }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      File.write(build_input, "console.log('custom changed')")
+
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_skips_build_when_source_dir_missing_but_build_inputs_are_fresh
+    build_input = File.join(@dir, "frontend/custom.js")
+    FileUtils.mkdir_p(File.dirname(build_input))
+    File.write(build_input, "console.log('custom')")
+    FileUtils.rm_rf(@source_dir)
+    write_build_meta(build_inputs: ["frontend/custom.js"])
+
+    with_root do
+      stub_build(->(*) { write_manifest }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      refute built
+    end
+  end
+
+  def test_builds_when_configured_build_input_is_missing
+    write_manifest
+    write_build_meta(build_inputs: ["frontend/missing.js"])
+
+    with_root do
+      built = false
+      stub_build(->(*) { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_does_not_cache_failed_build
+    with_root do
+      stub_build(->(*) { false }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      refute File.exist?(@config.auto_build_cache_path)
+
+      built = false
+      stub_build(->(*) {
+        built = true
+        write_manifest
+      }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert built
+    end
+  end
+
+  def test_does_not_cache_successful_build_without_manifest
+    with_root do
+      stub_build(->(*) { true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      refute File.exist?(@config.auto_build_cache_path)
+    end
+  end
+
+  def test_builds_when_source_dir_missing
     FileUtils.rm_rf(@source_dir)
     File.write(@manifest_path, "{}")
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.at(0))
+    with_root do
+      built = false
+      stub_build(->(*) { built = true }) do
+        middleware = RailsVite::AutoBuild.new(@app, @config)
+        middleware.call({})
+      end
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
+      assert built
     end
-
-    assert built
   end
 
   def test_passes_request_through_to_app
-    File.write(@manifest_path, "{}")
+    write_manifest(mtime: Time.now)
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.now + 10)
+    with_root do
+      middleware = RailsVite::AutoBuild.new(@app, @config)
 
-    status, = middleware.call({})
-    assert_equal 200, status
+      status, = middleware.call({})
+      assert_equal 200, status
+    end
   end
 
   private
 
+  def with_root(&block)
+    Rails.stub(:root, Pathname.new(@dir), &block)
+  end
+
+  def write_manifest(mtime: Time.now)
+    File.write(@manifest_path, "{}")
+    FileUtils.touch(@manifest_path, mtime: mtime)
+  end
+
+  def write_build_meta(build_inputs: [])
+    File.write(
+      @manifest_path.dirname.join("rails-vite.json"),
+      JSON.generate({buildInputs: build_inputs})
+    )
+  end
+
   def stub_build(callback)
     RailsVite::Tasks.stub(:build_command, "true") do
-      RailsVite::AutoBuild.define_method(:system) do |cmd|
-        callback.call
-        true
+      RailsVite::AutoBuild.define_method(:system) do |*args|
+        result = callback.call(*args)
+        result != false
       end
       yield
     ensure

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -27,6 +27,11 @@ class ConfigTest < Minitest::Test
     assert_equal Rails.root.join("public/custom/.vite/manifest.json"), @config.manifest_path
   end
 
+  def test_auto_build_cache_path
+    @config.manifest_path = Rails.root.join("public/custom/manifest.json")
+    assert_equal Rails.root.join("public/custom/rails-vite-auto-build.json"), @config.auto_build_cache_path
+  end
+
   def test_custom_asset_prefix
     @config.asset_prefix = "/custom"
     assert_equal "/custom", @config.asset_prefix
@@ -76,6 +81,23 @@ class ConfigTest < Minitest::Test
 
       assert_equal "app/frontend", @config.source_dir
     end
+  end
+
+  def test_build_inputs_from_build_meta
+    Dir.mktmpdir do |dir|
+      vite_dir = File.join(dir, ".vite")
+      FileUtils.mkdir_p(vite_dir)
+      File.write(File.join(vite_dir, "manifest.json"), "{}")
+      File.write(File.join(vite_dir, "rails-vite.json"), '{"buildInputs":["app/frontend/application.ts","/absolute/admin.ts",123]}')
+
+      @config.manifest_path = Pathname.new(File.join(vite_dir, "manifest.json"))
+
+      assert_equal ["app/frontend/application.ts", "/absolute/admin.ts"], @config.build_inputs
+    end
+  end
+
+  def test_build_inputs_empty_by_default
+    assert_equal [], @config.build_inputs
   end
 
   def test_auto_build_true_in_local_env


### PR DESCRIPTION
## Problem

When `auto_build` is enabled, `rails_vite` currently remembers the last build time only in memory.

That works inside one Rails process, but it falls apart for local system tests because Rails can boot a fresh process for another run. Each new process starts with:

```ruby
@last_build_at = Time.at(0)
```

So even if `public/vite-test/manifest.json` already exists and the JS/CSS files have not changed, the first request in the new process sees sources as newer than the in-memory timestamp and runs `vite build` again.

In practice this makes repeated local system-test runs noisier and slower than they need to be.

## Solution

This PR makes auto-build freshness durable.

During `vite build`, the Vite plugin now writes the resolved client inputs into `rails-vite.json`. After a successful middleware-triggered build, `rails_vite` writes a small `rails-vite-auto-build.json` file next to the manifest. It stores:

- a digest of files under `sourceDir`, resolved build inputs, and relevant config/package files
- the `rails_vite` version
- a build timestamp
- a success marker

On the next Rails boot, auto-build can read that file and skip `vite build` when the digest still matches.

`rails-vite.json` before:

```json
{
  "sourceDir": "app/javascript",
  "buildDir": "vite-test"
}
```

`rails-vite.json` after:

```json
{
  "sourceDir": "app/javascript",
  "buildDir": "vite-test",
  "buildInputs": [
    "app/javascript/application.js",
    "app/frontend/admin.js"
  ]
}
```

The new `rails-vite-auto-build.json` written after a successful auto-build looks like:

```json
{
  "success": true,
  "digest": "8a9f4c7f5f6c2e0b9c7f0a1d2e3f4b5c6d7e8f90123456789abcdef012345678",
  "version": "0.2.2",
  "builtAt": "2026-06-09T00:15:00Z"
}
```

The digest value changes whenever the tracked inputs change.

## Before

- Fresh Rails process means no remembered build state.
- Existing manifest is not enough to skip if source mtimes are newer than `NEVER`
- Unchanged assets can rebuild on every local system-test run.
- A failed build could still update the old in-memory timestamp.

## After

- Missing manifest still triggers a build.
- Existing builds without cache metadata still use the old manifest-mtime check.
- Successful auto-builds write persistent freshness metadata.
- New Rails processes skip `vite build` when inputs are unchanged.
- Changes to source files, resolved build inputs, `vite.config.*`, package files, lockfiles, or the `rails_vite` version invalidate the cache.
- Missing resolved build inputs trigger a build so Vite can surface the error.
- Failed builds do not write freshness metadata.
- A successful command that does not produce the manifest also does not write freshness metadata.

## Notes

This borrows the durable build metadata idea from [vite_ruby](https://github.com/ElMassimo/vite_ruby)'s [`Builder#build`](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/builder.rb#L421-L450), [`record_build_metadata`](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/builder.rb#L467-L473), and [`watched_files_digest`](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/builder.rb#L484-L501), but keeps it small and local to `rails_vite`'s existing build metadata and auto-build middleware. There is no new user-facing config and no change to helper behavior.

The issue comment also mentions silencing Vite build output in system tests. I left that out of this PR so this stays focused on avoiding redundant builds.

---

Resolves: https://github.com/skryukov/rails_vite/issues/21