### PR TITLE
Persist auto-build freshness across process restarts (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## Unreleased
+
+### Fixed
+
+- Persist auto-build freshness across process restarts so repeated local system-test runs no longer rebuild unchanged assets. Freshness now derives from the build manifest's timestamp instead of in-memory state (#21) ([@skryukov], [@brodienguyen])
+
 ## rails_vite@0.2.2 / rails-vite-plugin@0.2.4 - 2026-04-09
 
 ### Added
@@ -74,6 +80,7 @@ and this project adheres to [Semantic Versioning].
 - Initial release ([@skryukov])
 
 [@skryukov]: https://github.com/skryukov
+[@brodienguyen]: https://github.com/brodienguyen
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ node ssr/ssr.js
 
 When the Vite dev server is not running, rails_vite automatically rebuilds assets on the first request if sources have changed. This is useful for system tests and quick checks without running `bin/dev`.
 
+Freshness is determined by comparing your source files' timestamps against the build manifest's timestamp. Since the manifest lives on disk, unchanged assets are not rebuilt across process restarts — for example, on repeated local system-test runs.
+
 Disable it:
 
 ```ruby

--- a/lib/rails_vite/auto_build.rb
+++ b/lib/rails_vite/auto_build.rb
@@ -9,7 +9,6 @@ module RailsVite
       @app = app
       @config = config
       @mutex = Mutex.new
-      @last_build_at = NEVER
       @cached_source_mtime = nil
       @source_mtime_checked_at = nil
     end
@@ -26,15 +25,17 @@ module RailsVite
         return unless stale?
 
         Rails.logger.error("rails-vite: build failed") unless system(RailsVite::Tasks.build_command)
-        @last_build_at = Time.now
         @cached_source_mtime = nil
         @source_mtime_checked_at = nil
       end
     end
 
     def stale?
+      # The manifest file's mtime is our persisted "last build" timestamp: it
+      # lives on disk, so freshness survives process restarts (e.g. a new Rails
+      # process per local system-test run) without any extra state.
       !File.exist?(@config.manifest_path) ||
-        latest_source_mtime > @last_build_at
+        latest_source_mtime > File.mtime(@config.manifest_path)
     end
 
     def latest_source_mtime

--- a/test/auto_build_test.rb
+++ b/test/auto_build_test.rb
@@ -22,72 +22,103 @@ class AutoBuildTest < Minitest::Test
   end
 
   def test_builds_when_manifest_missing
-    built = false
-    stub_build(-> { built = true }) do
-      middleware = RailsVite::AutoBuild.new(@app, @config)
-      middleware.call({})
-    end
+    with_root do
+      built = false
+      stub_build(-> { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    assert built
+      assert built
+    end
   end
 
-  def test_builds_when_sources_newer_than_last_build
-    File.write(@manifest_path, "{}")
-
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-
-    # Simulate a previous build
-    middleware.instance_variable_set(:@last_build_at, Time.now - 10)
+  def test_builds_when_sources_are_newer_than_manifest
+    write_manifest(mtime: Time.now - 10)
     FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now)
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
-    end
+    with_root do
+      built = false
+      stub_build(-> { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    assert built
+      assert built
+    end
   end
 
-  def test_skips_build_when_manifest_fresh
-    File.write(@manifest_path, "{}")
+  def test_skips_build_when_manifest_is_newer_than_sources
+    FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now - 10)
+    write_manifest(mtime: Time.now)
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.now + 10)
+    with_root do
+      built = false
+      stub_build(-> { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
+      refute built
     end
+  end
 
-    refute built
+  def test_skips_build_across_instances_when_nothing_changed
+    # Issue #21: a fresh middleware instance (a new Rails process, e.g. each
+    # local system-test run) must not rebuild when assets are unchanged. The
+    # freshness signal is the manifest's on-disk mtime, so it persists.
+    FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now - 10)
+
+    with_root do
+      first_build = false
+      stub_build(-> {
+        first_build = true
+        write_manifest
+      }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      second_build = false
+      stub_build(-> { second_build = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
+
+      assert first_build
+      refute second_build
+    end
   end
 
   def test_missing_source_dir_triggers_build
     FileUtils.rm_rf(@source_dir)
-    File.write(@manifest_path, "{}")
+    write_manifest(mtime: Time.now)
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.at(0))
+    with_root do
+      built = false
+      stub_build(-> { built = true }) do
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      end
 
-    built = false
-    stub_build(-> { built = true }) do
-      middleware.call({})
+      assert built
     end
-
-    assert built
   end
 
   def test_passes_request_through_to_app
-    File.write(@manifest_path, "{}")
+    FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now - 10)
+    write_manifest(mtime: Time.now)
 
-    middleware = RailsVite::AutoBuild.new(@app, @config)
-    middleware.instance_variable_set(:@last_build_at, Time.now + 10)
-
-    status, = middleware.call({})
-    assert_equal 200, status
+    with_root do
+      status, = RailsVite::AutoBuild.new(@app, @config).call({})
+      assert_equal 200, status
+    end
   end
 
   private
+
+  def with_root(&block)
+    Rails.stub(:root, Pathname.new(@dir), &block)
+  end
+
+  def write_manifest(mtime: Time.now)
+    File.write(@manifest_path, "{}")
+    FileUtils.touch(@manifest_path, mtime: mtime)
+  end
 
   def stub_build(callback)
     RailsVite::Tasks.stub(:build_command, "true") do


### PR DESCRIPTION
## Problem

When `auto_build` is enabled, freshness is tracked only in memory:

```ruby
@last_build_at = NEVER   # reset on every process boot
```

So a fresh Rails process — e.g. each local system-test run — starts with no memory of the last build and rebuilds on the first request, even when the manifest already exists and nothing has changed. Fixes #21.

## Solution

Use the build manifest's own mtime as the persisted "last build" timestamp. It already lives on disk and is rewritten by every `vite build`, so freshness survives process restarts with **no new state, files, or digests**:

```ruby
def stale?
  !File.exist?(@config.manifest_path) ||
    latest_source_mtime > File.mtime(@config.manifest_path)
end
```

The whole change is ~7 lines in `auto_build.rb` (it deletes the in-memory `@last_build_at` tracking) plus tests, a README note, and a changelog entry.

A nice side effect: a failed build no longer marks assets fresh — the manifest isn't rewritten on failure, so the next request still rebuilds.

## Relationship to #29

This is a deliberately minimal alternative to #29, which solved the same issue with a durable content-digest cache (`rails-vite-auto-build.json`, hashing the source tree, tracking build inputs and config/lockfiles). #29's own no-metadata fallback is exactly this manifest-mtime check — this PR keeps that and drops the digest layer to keep the gem lean.

**Trade-off vs #29:** mtime-based freshness does **not** invalidate on `package.json`/`vite.config`/lockfile or gem-version changes, and can miss a content change that preserves an older mtime (stash/checkout). None of these were handled before #29 either, so this is not a regression from current `main` — it's scoped to exactly what #21 asks for. If dep/config invalidation is wanted later, a small digest of just those files can be added.

Credit to @brodienguyen (#29) for surfacing and validating the approach.

## Tests

`auto_build_test.rb` rewritten around manifest-mtime semantics, including a cross-instance test that builds with one middleware instance and asserts a second fresh instance skips — the #21 scenario. Full suite green; `standardrb` clean.

Resolves #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)