### PR TITLE
Run auto builds quietly (vite --logLevel warn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## Unreleased
 
+### Changed
+
+- Auto builds now run quietly (`vite build --logLevel warn`) to keep system-test output clean; warnings and errors are still shown ([@skryukov])
+
 ### Fixed
 
 - Persist auto-build freshness across process restarts so repeated local system-test runs no longer rebuild unchanged assets. Freshness now derives from the build manifest's timestamp instead of in-memory state (#21) ([@skryukov], [@brodienguyen])

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ When the Vite dev server is not running, rails_vite automatically rebuilds asset
 
 Freshness is determined by comparing your source files' timestamps against the build manifest's timestamp. Since the manifest lives on disk, unchanged assets are not rebuilt across process restarts — for example, on repeated local system-test runs.
 
+Auto builds run quietly (`vite build --logLevel warn`), so they don't clutter your test output; warnings and errors are still shown. Run `rake vite:build` directly for the full build log.
+
 Disable it:
 
 ```ruby

--- a/lib/rails_vite/auto_build.rb
+++ b/lib/rails_vite/auto_build.rb
@@ -24,7 +24,9 @@ module RailsVite
       @mutex.synchronize do
         return unless stale?
 
-        Rails.logger.error("rails-vite: build failed") unless system(RailsVite::Tasks.build_command)
+        # Build quietly: vite's per-build summary is noise on every auto-build
+        # (e.g. each local system-test run). Warnings and errors still stream.
+        Rails.logger.error("rails-vite: build failed") unless system("#{RailsVite::Tasks.build_command} --logLevel warn")
         @cached_source_mtime = nil
         @source_mtime_checked_at = nil
       end

--- a/test/auto_build_test.rb
+++ b/test/auto_build_test.rb
@@ -32,6 +32,23 @@ class AutoBuildTest < Minitest::Test
     end
   end
 
+  def test_runs_the_build_quietly
+    captured = nil
+    with_root do
+      RailsVite::Tasks.stub(:build_command, "vite build") do
+        RailsVite::AutoBuild.define_method(:system) do |cmd|
+          captured = cmd
+          true
+        end
+        RailsVite::AutoBuild.new(@app, @config).call({})
+      ensure
+        RailsVite::AutoBuild.remove_method(:system)
+      end
+    end
+
+    assert_includes captured, "--logLevel warn"
+  end
+
   def test_builds_when_sources_are_newer_than_manifest
     write_manifest(mtime: Time.now - 10)
     FileUtils.touch(File.join(@source_dir, "app.js"), mtime: Time.now)


### PR DESCRIPTION
## Problem

When `auto_build` triggers a build, it runs a full `vite build` whose per-build summary streams to the console:

```
vite vX building for production...
✓ 34 modules transformed.
dist/assets/...  ...
✓ built in 1.2s
```

On a per-request auto-build (most painfully, once per local system-test run) this is just noise. Raised in the #21 discussion.

## Solution

Pass `--logLevel warn` at the **auto-build call site only**:

```ruby
Rails.logger.error("rails-vite: build failed") unless
  system("#{RailsVite::Tasks.build_command} --logLevel warn")
```

- **Silent on success** — verified against a real `vite build`: `--logLevel warn` produces zero output for a clean build, while `info` dumps the full summary.
- **Failures still visible** — verified by inducing a build error: at `--logLevel warn` vite still prints the error and exits non-zero, so the failure path is unchanged (and `Rails.logger.error` still fires).
- **`rake vite:build` untouched** — the flag is appended at the call site, not in `Tasks.build_command`, so the explicit build command stays fully verbose. (`tasks_test.rb`'s exact-string assertions remain green.)

## Scope

Applies whenever auto-build runs (dev + test). Auto-build is a background convenience; run `bin/dev` or `rake vite:build` when you want the full build log. `warn` (not `error`) is used so build *warnings* still surface.

## Tests

Adds `test_runs_the_build_quietly`, asserting the auto-build path invokes the build with `--logLevel warn`. Full suite green; `standardrb` clean.

Follow-up to #30 (the other half of the #21 discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)