### PR TITLE
Support Vite `root` == `sourceDir` via `prependSourceDirToEntries` (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## Unreleased
 
+### Added
+
+- `prependSourceDirToEntries` plugin option for `rails()` and `jsbundling()`. Set it to `false` to use Vite's `root` as your `sourceDir` — entries are then resolved by their bare, root-relative names instead of being prefixed with `sourceDir` (#22) ([@skryukov])
+
 ### Changed
 
 - Auto builds now run quietly (`vite build --logLevel warn`) to keep system-test output clean; warnings and errors are still shown ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ export default defineConfig({
 | `buildDir` | `'vite'` | Build output subdirectory inside `public/` |
 | `publicDir` | `'public'` | Public directory |
 | `refresh` | `true` | Paths to watch for full-page reload. `true` watches `app/views/**` and `app/helpers/**` |
+| `prependSourceDirToEntries` | `true` | When `false`, entries are resolved without the `sourceDir` prefix. Set this when Vite's `root` is your `sourceDir` (see below) |
 
 ### Multiple Entry Points
 
@@ -207,6 +208,26 @@ rails({
 ```erb
 <%= vite_tags "entrypoints/application.ts" %>
 ```
+
+### Setting Vite's `root` to your source directory
+
+By default, `root` is the Rails project root, so `import.meta.glob` keys and manifest entries are prefixed with `sourceDir` (e.g. `app/frontend/components/Foo.jsx`). If you prefer `vite_ruby`-style root-relative names (`components/Foo.jsx`), set Vite's `root` to your source directory and tell the plugin not to prepend `sourceDir`:
+
+```typescript
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  root: fileURLToPath(new URL('./app/frontend', import.meta.url)),
+  plugins: [
+    rails({ sourceDir: 'app/frontend', prependSourceDirToEntries: false }),
+  ],
+  build: {
+    outDir: fileURLToPath(new URL('./public/vite', import.meta.url)),
+  },
+})
+```
+
+With `root` set to the source directory, Vite emits bare manifest keys, and `prependSourceDirToEntries: false` makes the Rails helpers look them up by those bare names. Set both together. (Don't point `root` at a symlinked path — Vite resolves symlinks and emits keys that escape the root.)
 
 ## Adding Frameworks
 

--- a/lib/rails_vite/tag_helper.rb
+++ b/lib/rails_vite/tag_helper.rb
@@ -111,10 +111,13 @@ module RailsVite
     end
 
     def resolve_vite_entry(entry, source_dir, entrypoints_dir)
-      return entry if entry.start_with?("#{source_dir}/", "/")
+      return entry if entry.start_with?("/")
+      return entry if !source_dir.empty? && entry.start_with?("#{source_dir}/")
 
-      prefix = entrypoints_dir ? "#{source_dir}/#{entrypoints_dir}" : source_dir
-      "#{prefix}/#{entry}"
+      # source_dir is empty when the plugin's `root` is the source directory
+      # (prependSourceDirToEntries: false) — entries are then looked up by their
+      # bare, manifest-relative names.
+      [source_dir, entrypoints_dir, entry].reject { |part| part.nil? || part.empty? }.join("/")
     end
 
     def vite_asset_url(file)

--- a/packages/rails-vite-plugin/src/index.ts
+++ b/packages/rails-vite-plugin/src/index.ts
@@ -12,7 +12,7 @@ import {
 
 import type { InputOption } from './shared/types.js'
 import { ORIGIN_PLACEHOLDER } from './shared/types.js'
-import { resolveInput, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint } from './shared/entries.js'
+import { resolveInput, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint, resolveManifestSourceDir } from './shared/entries.js'
 import { resolveAlias } from './shared/alias.js'
 import { resolveDevServerUrl, isAddressInfo, replaceOriginPlaceholder } from './shared/dev-server.js'
 import { resolveBundlerOptionsKey, getUserBundlerInput } from './shared/bundler-compat.js'
@@ -36,10 +36,13 @@ export interface RailsViteOptions {
   /** Public directory (default: 'public') */
   publicDir?: string
   refresh?: boolean | string | string[]
+  /** When false, manifest entries are looked up without the sourceDir prefix. Set this when Vite's `root` is your sourceDir. Default: true */
+  prependSourceDirToEntries?: boolean
 }
 
 export default function rails(options: RailsViteOptions = {}): Plugin {
   const sourceDir = options.sourceDir ?? 'app/javascript'
+  const manifestSourceDir = resolveManifestSourceDir(sourceDir, options.prependSourceDirToEntries)
   const entrypointsDir = options.input === undefined ? detectEntrypointsDir(sourceDir) : null
   const input = options.input ?? (entrypointsDir ? discoverEntrypointInputs(sourceDir, entrypointsDir) : detectEntrypoint(sourceDir))
   const publicDir = options.publicDir ?? 'public'
@@ -105,7 +108,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
       if (resolvedConfig.build.ssr) return
 
       const outDir = resolvedConfig.build.outDir
-      const meta: Record<string, unknown> = { sourceDir, buildDir: effectiveBuildDir }
+      const meta: Record<string, unknown> = { sourceDir: manifestSourceDir, buildDir: effectiveBuildDir }
       if (entrypointsDir) meta.entrypointsDir = entrypointsDir
       if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
       fs.writeFileSync(path.join(outDir, 'rails-vite.json'), JSON.stringify(meta))
@@ -124,7 +127,7 @@ export default function rails(options: RailsViteOptions = {}): Plugin {
         if (isAddressInfo(address)) {
           devServerUrl = resolveDevServerUrl(address, resolvedConfig)
 
-          const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, buildDir: effectiveBuildDir, pid: process.pid }
+          const meta: Record<string, unknown> = { url: devServerUrl, sourceDir: manifestSourceDir, buildDir: effectiveBuildDir, pid: process.pid }
           if (entrypointsDir) meta.entrypointsDir = entrypointsDir
           if (resolvedSsr) meta.ssrOutputDir = ssrOutDir
           if (reactRefresh) meta.reactRefresh = true

--- a/packages/rails-vite-plugin/src/jsbundling.ts
+++ b/packages/rails-vite-plugin/src/jsbundling.ts
@@ -12,7 +12,7 @@ import {
 
 import type { InputOption, ResolvedEntry } from './shared/types.js'
 import { ORIGIN_PLACEHOLDER } from './shared/types.js'
-import { resolveEntries, entriesToRollupInput, prefixWithSourceDir, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint, isEntrypointFile } from './shared/entries.js'
+import { resolveEntries, entriesToRollupInput, prefixWithSourceDir, detectEntrypointsDir, discoverEntrypointInputs, detectEntrypoint, isEntrypointFile, resolveManifestSourceDir } from './shared/entries.js'
 import { resolveAlias } from './shared/alias.js'
 import { resolveDevServerUrl, isAddressInfo, replaceOriginPlaceholder } from './shared/dev-server.js'
 import { resolveBundlerOptionsKey, getUserBundlerInput } from './shared/bundler-compat.js'
@@ -45,10 +45,13 @@ export interface JsbundlingOptions {
   /** Path to write dev server metadata JSON (default: 'tmp/rails-vite.json').
    *  Set to false to disable. Useful as a bridge for progressive upgrade to the rails_vite gem. */
   devMetaFile?: string | false
+  /** When false, dev-server URLs are built without the sourceDir prefix. Set this when Vite's `root` is your sourceDir. Default: true */
+  prependSourceDirToEntries?: boolean
 }
 
 export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
   const sourceDir = options.sourceDir ?? 'app/javascript'
+  const manifestSourceDir = resolveManifestSourceDir(sourceDir, options.prependSourceDirToEntries)
   const epDir = detectEntrypointsDir(sourceDir)
   const input = options.input ?? (epDir ? discoverEntrypointInputs(sourceDir, epDir) : detectEntrypoint(sourceDir))
   const assetPipelineDir = options.assetPipelineDir ?? 'app/assets/builds'
@@ -250,7 +253,7 @@ export default function jsbundling(options: JsbundlingOptions = {}): Plugin {
 
           // Write dev meta file for progressive upgrade to the rails_vite gem
           if (devMetaPath) {
-            const meta: Record<string, unknown> = { url: devServerUrl, sourceDir, pid: process.pid }
+            const meta: Record<string, unknown> = { url: devServerUrl, sourceDir: manifestSourceDir, pid: process.pid }
             if (epDir) meta.entrypointsDir = epDir
             if (ssrConfig) meta.ssrOutputDir = ssrConfig.outDir
             if (reactRefresh) meta.reactRefresh = true

--- a/packages/rails-vite-plugin/src/shared/entries.ts
+++ b/packages/rails-vite-plugin/src/shared/entries.ts
@@ -61,6 +61,16 @@ export function prefixWithSourceDir(entry: string, sourceDir: string): string {
   return `${sourceDir}/${entry}`
 }
 
+/**
+ * The sourceDir prefix the Rails helpers should prepend to manifest entries.
+ * Empty when `prependSourceDirToEntries` is false (Vite's `root` is the sourceDir,
+ * so entries are already root-relative). `=== false` keeps the default `true` when
+ * the option is omitted.
+ */
+export function resolveManifestSourceDir(sourceDir: string, prependSourceDirToEntries: boolean | undefined): string {
+  return prependSourceDirToEntries === false ? '' : sourceDir
+}
+
 export function detectEntrypointsDir(sourceDir: string): string | null {
   const entrypointsDir = path.join(sourceDir, 'entrypoints')
   return fs.existsSync(entrypointsDir) ? 'entrypoints' : null

--- a/packages/rails-vite-plugin/tests/index.test.ts
+++ b/packages/rails-vite-plugin/tests/index.test.ts
@@ -499,6 +499,41 @@ describe('rails-vite-plugin', () => {
     expect(bindExitHandler).toHaveBeenCalledOnce()
   })
 
+  // --- prependSourceDirToEntries (root == sourceDir) ---
+
+  it('writes the sourceDir prefix to build meta by default', () => {
+    const plugin = rails({ input: 'application.js', sourceDir: 'app/frontend' })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+    ;(plugin.writeBundle as unknown as () => void)()
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('public/vite', 'rails-vite.json'))
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({ sourceDir: 'app/frontend' })
+  })
+
+  it('writes an empty sourceDir to build meta when prependSourceDirToEntries is false', () => {
+    const plugin = rails({ input: 'application.js', sourceDir: 'app/frontend', prependSourceDirToEntries: false })
+    getConfig(plugin)
+    callConfigResolved(plugin)
+    ;(plugin.writeBundle as unknown as () => void)()
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('public/vite', 'rails-vite.json'))
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({ sourceDir: '' })
+  })
+
+  it('writes an empty sourceDir to dev meta when prependSourceDirToEntries is false', () => {
+    const plugin = rails({ input: 'application.js', sourceDir: 'app/frontend', prependSourceDirToEntries: false })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    callConfigureServer(plugin, server)
+    server._emit('listening')
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('tmp', 'rails-vite.json'))
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({ sourceDir: '' })
+  })
+
   // --- Refresh paths ---
 
   it('exports refreshPaths', () => {

--- a/packages/rails-vite-plugin/tests/jsbundling.test.ts
+++ b/packages/rails-vite-plugin/tests/jsbundling.test.ts
@@ -886,6 +886,19 @@ describe('rails-vite-plugin/jsbundling', () => {
     expect(bindExitHandler).toHaveBeenCalledTimes(2)
   })
 
+  it('writes an empty sourceDir to dev meta when prependSourceDirToEntries is false', () => {
+    const plugin = jsbundling({ input: 'application.js', sourceDir: 'app/frontend', prependSourceDirToEntries: false })
+    getConfig(plugin, {}, SERVE)
+    callConfigResolved(plugin)
+
+    const server = createMockServer()
+    ;(plugin.configureServer as Function)(server)
+    server._emit('listening')
+
+    const metaWrite = vi.mocked(fs.writeFileSync).mock.calls.find(([filePath]) => filePath === path.join('tmp', 'rails-vite.json'))
+    expect(JSON.parse(String(metaWrite![1]))).toMatchObject({ sourceDir: '' })
+  })
+
   // --- writeDevStubs: CSS entries ---
 
   it('writes empty CSS stubs for CSS entries', () => {

--- a/packages/rails-vite-plugin/tests/root-as-sourcedir.integration.test.ts
+++ b/packages/rails-vite-plugin/tests/root-as-sourcedir.integration.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { build } from 'vite'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import rails from '../src'
+
+// Real `vite build` (no mocked fs) — the regression guard for issue #22.
+// Mocked hook tests can't see the actual manifest keys Vite emits, which is
+// exactly how the prefix mismatch went unnoticed. This builds for real and
+// asserts the on-disk manifest + rails-vite.json.
+describe('root == sourceDir, real build', () => {
+  let dir: string
+
+  beforeAll(() => {
+    // realpath so root/input share one symlink space (macOS /var -> /private/var);
+    // an absolute input avoids depending on the process cwd.
+    dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'rv-issue22-')))
+    fs.mkdirSync(path.join(dir, 'app/frontend/entrypoints'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'app/frontend/entrypoints/demos.js'), 'export const demo = 1\n')
+  })
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  function readManifest(outDir: string): Record<string, unknown> {
+    for (const p of [path.join(outDir, '.vite', 'manifest.json'), path.join(outDir, 'manifest.json')]) {
+      if (fs.existsSync(p)) return JSON.parse(fs.readFileSync(p, 'utf8'))
+    }
+    throw new Error(`manifest not found under ${outDir}`)
+  }
+
+  it('emits bare manifest keys and empty sourceDir when prependSourceDirToEntries is false', async () => {
+    const root = path.join(dir, 'app/frontend')
+    const outDir = path.join(dir, 'out')
+
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'error',
+      plugins: [
+        rails({
+          sourceDir: root,
+          input: path.join(root, 'entrypoints/demos.js'),
+          prependSourceDirToEntries: false,
+        }),
+      ],
+      build: { outDir, emptyOutDir: true },
+    })
+
+    const manifest = readManifest(outDir)
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'rails-vite.json'), 'utf8'))
+
+    // Vite keys the entry relative to root -> bare, no sourceDir prefix.
+    expect(Object.keys(manifest)).toContain('entrypoints/demos.js')
+    // The gem must therefore NOT prepend sourceDir.
+    expect(meta.sourceDir).toBe('')
+  })
+})

--- a/test/tag_helper_test.rb
+++ b/test/tag_helper_test.rb
@@ -265,6 +265,34 @@ class TagHelperTest < Minitest::Test
     assert_match %r{src="/vite/assets/application-a1b2c3d4.js"}, html
   end
 
+  # root == sourceDir (prependSourceDirToEntries: false) — bare manifest keys
+
+  def test_vite_tags_root_as_source_dir_production
+    File.write(File.join(File.dirname(@manifest_path), "rails-vite.json"),
+      '{"sourceDir":"","entrypointsDir":"entrypoints"}')
+
+    custom_manifest = {
+      "entrypoints/application.js" => {
+        "file" => "assets/application-bare.js",
+        "isEntry" => true, "css" => [], "imports" => []
+      }
+    }
+    File.write(@manifest_path, JSON.generate(custom_manifest))
+
+    html = vite_tags("application.js")
+
+    assert_match %r{src="/vite/assets/application-bare.js"}, html
+  end
+
+  def test_vite_tags_root_as_source_dir_dev_mode
+    File.write(File.join(@dir, "rails-vite.json"),
+      '{"url":"http://localhost:5173","sourceDir":"","entrypointsDir":"entrypoints"}')
+
+    html = vite_tags("application.js")
+
+    assert_match %r{src="http://localhost:5173/entrypoints/application.js"}, html
+  end
+
   # React refresh preamble tests
 
   def test_vite_tags_dev_mode_with_react_refresh


### PR DESCRIPTION
## Problem

Setting Vite's `root` to your source directory (e.g. `app/frontend`) — to get short, `vite_ruby`-style `import.meta.glob` keys — breaks the Rails helpers:

```
RailsVite::MissingEntryError:
Entry "app/frontend/entrypoints/demos.js" not found in Vite manifest...
```

With `root` set to the source dir, Vite emits **bare** manifest keys (`entrypoints/demos.js`), but the gem unconditionally prepends `sourceDir` and looks up `app/frontend/entrypoints/demos.js`. Resolves #22.

## Solution

Add the `prependSourceDirToEntries` option (default `true`) the issue requested, on both `rails()` and `jsbundling()`. When `false`, the plugin writes an **empty** `sourceDir` to `rails-vite.json`, and the gem resolves entries by their bare, root-relative names.

```ts
export default defineConfig({
  root: fileURLToPath(new URL('./app/frontend', import.meta.url)),
  plugins: [rails({ sourceDir: 'app/frontend', prependSourceDirToEntries: false })],
})
```

- `resolve_vite_entry` is restructured to handle an empty `sourceDir` (a leading-slash bug otherwise). Behavior is unchanged for the existing prefixed case.
- `jsbundling()` applies it to the dev-server meta (its production path uses the asset pipeline, so it has no manifest-prefix issue).

## Note on the issue's proposed mechanism

The issue suggested controlling *whether `sourceDir` is written*. Omitting it doesn't work — `config.source_dir` falls back to the `"app/javascript"` default and still prepends. So the plugin writes `sourceDir: ""` (truthy-empty in Ruby) instead, which achieves the issue's intent (bare lookup).

## Tests

- Ruby: bare-name resolution (prod + dev), backward-compat prefixing unchanged.
- JS: empty `sourceDir` in build + dev meta when `false`; prefix retained by default.
- **Real `vite build` integration test** (no mocked `fs`) asserting the on-disk manifest key is bare and `rails-vite.json` `sourceDir` is empty — the contract mocked hook tests can't see, which is how earlier attempts shipped broken.

Backward compatible: default `true` is unchanged.

Caveat (documented): set `root` *and* `prependSourceDirToEntries: false` together, and don't point `root` at a symlinked path (Vite resolves symlinks and emits keys that escape the root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)