### PR TITLE
Derive dev @vite/client nonce from the request (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
+- `RailsVite.dev_server_csp_source` returns a Content Security Policy source for the running Vite dev server, resolved per request so it tracks the real (possibly auto-incremented) port and adds nothing when the server is down. Pass `websocket: true` for the HMR socket (#25) ([@skryukov])
 - `prependSourceDirToEntries` plugin option for `rails()` and `jsbundling()`. Set it to `false` to use Vite's `root` as your `sourceDir` — entries are then resolved by their bare, root-relative names instead of being prefixed with `sourceDir` (#22) ([@skryukov])
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning].
 
 ### Fixed
 
+- The development `@vite/client` and React Fast Refresh tags now derive their nonce from the request (`content_security_policy_nonce`) instead of inheriting whatever nonce the first `vite_*` call passed. A nonce-less first call (e.g. a stylesheet) no longer ships a nonce-less client script under a `strict-dynamic` CSP (#25) ([@skryukov])
 - Persist auto-build freshness across process restarts so repeated local system-test runs no longer rebuild unchanged assets. Freshness now derives from the build manifest's timestamp instead of in-memory state (#21) ([@skryukov], [@brodienguyen])
 
 ## rails_vite@0.2.2 / rails-vite-plugin@0.2.4 - 2026-04-09

--- a/README.md
+++ b/README.md
@@ -107,10 +107,39 @@ CSS files are detected by extension and emit `<link rel="stylesheet">`:
 <%= vite_tags "application.css" %>
 ```
 
-### CSP Nonces
+### Content Security Policy
+
+Pass a `nonce` to any tag helper and it's applied to every tag it emits:
 
 ```erb
 <%= vite_tags "application.js", nonce: content_security_policy_nonce %>
+```
+
+In development the Vite dev server injects its `@vite/client` script (and the
+React Fast Refresh preamble) on your first `vite_*` call. Those tags pick up the
+request's nonce automatically via `content_security_policy_nonce`, so they stay
+valid under a `strict-dynamic` policy even when your first call is a nonce-less
+stylesheet — you only need to nonce your own entry tags.
+
+To let the browser reach the dev server, allow its URL in your policy. Wrap each
+source in a lambda so it's resolved per request (the dev server may not be
+running when the app boots, and a lambda adds nothing when the URL is absent):
+
+```ruby
+# config/initializers/content_security_policy.rb
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    # ...your existing directives...
+
+    if Rails.env.development?
+      dev_server = -> { RailsVite.config.dev_server_url }
+      policy.script_src(*policy.script_src, dev_server)
+      policy.style_src(*policy.style_src, dev_server)
+      # HMR websocket — http(s) -> ws(s)
+      policy.connect_src(*policy.connect_src, -> { RailsVite.config.dev_server_url&.sub(/\Ahttp/, "ws") })
+    end
+  end
+end
 ```
 
 ### Subresource Integrity (SRI)

--- a/README.md
+++ b/README.md
@@ -109,37 +109,22 @@ CSS files are detected by extension and emit `<link rel="stylesheet">`:
 
 ### Content Security Policy
 
-Pass a `nonce` to any tag helper and it's applied to every tag it emits:
+Pass a `nonce` to any tag helper; it's applied to every tag it emits:
 
 ```erb
 <%= vite_tags "application.js", nonce: content_security_policy_nonce %>
 ```
 
-In development the Vite dev server injects its `@vite/client` script (and the
-React Fast Refresh preamble) on your first `vite_*` call. Those tags pick up the
-request's nonce automatically via `content_security_policy_nonce`, so they stay
-valid under a `strict-dynamic` policy even when your first call is a nonce-less
-stylesheet — you only need to nonce your own entry tags.
+The dev server's `@vite/client` and React Fast Refresh tags pick up the request nonce automatically, so they work under `strict-dynamic` even when your first `vite_*` call is a nonce-less stylesheet.
 
-If you run a restrictive CSP **in development** (Rails ships it disabled by
-default), the browser will block the Vite dev server unless you allow its origin.
-`RailsVite.dev_server_csp_source` returns a source that's resolved per request,
-so it tracks the dev server's real port (Vite may pick another if the default is
-taken) and contributes nothing when the server isn't running:
+Running a CSP in development? Allow the dev server's origin with `RailsVite.dev_server_csp_source` — it resolves per request, so it tracks Vite's actual port and adds nothing when the server is down:
 
 ```ruby
-# config/initializers/content_security_policy.rb
-Rails.application.configure do
-  config.content_security_policy do |policy|
-    # ...your existing directives...
-
-    if Rails.env.development?
-      policy.script_src(*policy.script_src, RailsVite.dev_server_csp_source)
-      policy.style_src(*policy.style_src, RailsVite.dev_server_csp_source)
-      # HMR websocket
-      policy.connect_src(*policy.connect_src, RailsVite.dev_server_csp_source(websocket: true))
-    end
-  end
+# config/initializers/content_security_policy.rb — inside your `policy` block
+if Rails.env.development?
+  policy.script_src(*policy.script_src, RailsVite.dev_server_csp_source)
+  policy.style_src(*policy.style_src, RailsVite.dev_server_csp_source)
+  policy.connect_src(*policy.connect_src, RailsVite.dev_server_csp_source(websocket: true)) # HMR
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ request's nonce automatically via `content_security_policy_nonce`, so they stay
 valid under a `strict-dynamic` policy even when your first call is a nonce-less
 stylesheet — you only need to nonce your own entry tags.
 
-To let the browser reach the dev server, allow its URL in your policy. Wrap each
-source in a lambda so it's resolved per request (the dev server may not be
-running when the app boots, and a lambda adds nothing when the URL is absent):
+If you run a restrictive CSP **in development** (Rails ships it disabled by
+default), the browser will block the Vite dev server unless you allow its origin.
+`RailsVite.dev_server_csp_source` returns a source that's resolved per request,
+so it tracks the dev server's real port (Vite may pick another if the default is
+taken) and contributes nothing when the server isn't running:
 
 ```ruby
 # config/initializers/content_security_policy.rb
@@ -132,11 +134,10 @@ Rails.application.configure do
     # ...your existing directives...
 
     if Rails.env.development?
-      dev_server = -> { RailsVite.config.dev_server_url }
-      policy.script_src(*policy.script_src, dev_server)
-      policy.style_src(*policy.style_src, dev_server)
-      # HMR websocket — http(s) -> ws(s)
-      policy.connect_src(*policy.connect_src, -> { RailsVite.config.dev_server_url&.sub(/\Ahttp/, "ws") })
+      policy.script_src(*policy.script_src, RailsVite.dev_server_csp_source)
+      policy.style_src(*policy.style_src, RailsVite.dev_server_csp_source)
+      # HMR websocket
+      policy.connect_src(*policy.connect_src, RailsVite.dev_server_csp_source(websocket: true))
     end
   end
 end

--- a/lib/rails_vite.rb
+++ b/lib/rails_vite.rb
@@ -24,6 +24,24 @@ module RailsVite
       manifest.digest
     end
 
+    # A Content Security Policy source for the running Vite dev server, e.g.
+    #
+    #   policy.script_src(*policy.script_src, RailsVite.dev_server_csp_source)
+    #   policy.connect_src(*policy.connect_src, RailsVite.dev_server_csp_source(websocket: true))
+    #
+    # Returns a lambda so the URL is resolved per request: it tracks the dev
+    # server's real (possibly auto-incremented) port and contributes nothing
+    # when the server isn't running. Pass websocket: true for the HMR socket
+    # (http -> ws, https -> wss). RailsVite.config is referenced explicitly
+    # because Rails resolves CSP Proc sources via instance_exec, which rebinds
+    # self to the controller.
+    def dev_server_csp_source(websocket: false)
+      -> {
+        url = RailsVite.config.dev_server_url
+        url && (websocket ? url.sub(/\Ahttp/, "ws") : url)
+      }
+    end
+
     def reset!
       @config = nil
       @manifest = nil

--- a/lib/rails_vite/tag_helper.rb
+++ b/lib/rails_vite/tag_helper.rb
@@ -47,8 +47,14 @@ module RailsVite
       tags = []
 
       unless @_vite_client_emitted
+        # The client/react-refresh tags are emitted once, on the first vite_*
+        # call. Their nonce must come from the request — not from whichever call
+        # happened to be first — so a nonce-less first call (e.g. a stylesheet)
+        # doesn't ship a nonce-less @vite/client under a `strict-dynamic` CSP (#25).
+        client_nonce = nonce || (content_security_policy_nonce if respond_to?(:content_security_policy_nonce))
+
         if RailsVite.config.react_refresh?
-          tags << tag.script(type: "module", nonce: nonce) {
+          tags << tag.script(type: "module", nonce: client_nonce) {
             <<~JS.squish.html_safe
               import{injectIntoGlobalHook}from'#{dev_url}/@react-refresh';
               injectIntoGlobalHook(window);
@@ -57,7 +63,7 @@ module RailsVite
             JS
           }
         end
-        tags << tag.script(src: "#{dev_url}/@vite/client", type: "module", nonce: nonce)
+        tags << tag.script(src: "#{dev_url}/@vite/client", type: "module", nonce: client_nonce)
         @_vite_client_emitted = true
       end
 

--- a/test/dev_server_csp_source_test.rb
+++ b/test/dev_server_csp_source_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+require "action_dispatch/http/content_security_policy"
+
+class DevServerCspSourceTest < Minitest::Test
+  def setup
+    @dir = Dir.mktmpdir
+    RailsVite.reset!
+    config = RailsVite.config
+    config.manifest_path = Pathname.new(File.join(@dir, "vite", "manifest.json"))
+    config.dev_meta_path = Pathname.new(File.join(@dir, "rails-vite.json"))
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+    RailsVite.reset!
+  end
+
+  def write_meta(url)
+    File.write(File.join(@dir, "rails-vite.json"), JSON.generate("url" => url, "sourceDir" => "app/javascript"))
+  end
+
+  # Unit: the lambda's own logic
+
+  def test_returns_dev_server_url_when_running
+    write_meta("http://localhost:5199") # a walked (non-default) port
+
+    assert_equal "http://localhost:5199", RailsVite.dev_server_csp_source.call
+  end
+
+  def test_websocket_transforms_http_to_ws
+    write_meta("http://localhost:5199")
+
+    assert_equal "ws://localhost:5199", RailsVite.dev_server_csp_source(websocket: true).call
+  end
+
+  def test_websocket_transforms_https_to_wss
+    write_meta("https://localhost:5173")
+
+    assert_equal "wss://localhost:5173", RailsVite.dev_server_csp_source(websocket: true).call
+  end
+
+  def test_nil_when_server_down
+    # No meta file written -> dev_server_url is nil.
+    assert_nil RailsVite.dev_server_csp_source.call
+    assert_nil RailsVite.dev_server_csp_source(websocket: true).call
+  end
+
+  # The real proof: per-request resolution inside an actual CSP build.
+
+  def test_resolves_in_real_csp_build_and_survives_self_rebinding
+    write_meta("http://localhost:5199")
+
+    policy = ActionDispatch::ContentSecurityPolicy.new do |p|
+      p.script_src(*p.script_src, "'self'", RailsVite.dev_server_csp_source)
+      p.connect_src(*p.connect_src, "'self'", RailsVite.dev_server_csp_source(websocket: true))
+    end
+
+    # Rails resolves Proc sources via `context.instance_exec(&source)`, rebinding
+    # `self` to the controller. This context has its OWN `config` method — a naive
+    # `-> { config.dev_server_url }` would call this and raise. Proves the helper
+    # qualifies RailsVite.config.
+    trap_context = Object.new
+    def trap_context.config
+      raise "lambda resolved against the wrong self"
+    end
+
+    built = policy.build(trap_context)
+
+    assert_includes built, "script-src 'self' http://localhost:5199"
+    assert_includes built, "connect-src 'self' ws://localhost:5199"
+  end
+
+  def test_real_csp_build_drops_source_when_server_down
+    policy = ActionDispatch::ContentSecurityPolicy.new do |p|
+      p.script_src(*p.script_src, "'self'", RailsVite.dev_server_csp_source)
+    end
+
+    assert_equal "script-src 'self'", policy.build(Object.new)
+  end
+end

--- a/test/tag_helper_test.rb
+++ b/test/tag_helper_test.rb
@@ -350,6 +350,43 @@ class TagHelperTest < Minitest::Test
     assert_match %r{application.js.*nonce="dev123"}, html
   end
 
+  def test_vite_dev_client_uses_request_nonce_when_first_call_nonceless
+    File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript"}')
+    define_singleton_method(:content_security_policy_nonce) { "req-nonce-abc" }
+
+    html = vite_stylesheet_tag("app/javascript/admin.css")
+
+    assert_match %r{@vite/client.*nonce="req-nonce-abc"}, html
+  end
+
+  def test_vite_dev_react_refresh_uses_request_nonce_when_first_call_nonceless
+    File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript","reactRefresh":true}')
+    define_singleton_method(:content_security_policy_nonce) { "req-nonce-abc" }
+
+    html = vite_stylesheet_tag("app/javascript/admin.css")
+
+    assert_match %r{nonce="req-nonce-abc">[^<]*@react-refresh}, html
+  end
+
+  def test_vite_dev_explicit_nonce_overrides_request_nonce
+    File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript"}')
+    define_singleton_method(:content_security_policy_nonce) { "req-nonce-abc" }
+
+    html = vite_javascript_tag("app/javascript/application.js", nonce: "explicit-123")
+
+    assert_match %r{@vite/client.*nonce="explicit-123"}, html
+    refute_match %r{nonce="req-nonce-abc"}, html
+  end
+
+  def test_vite_dev_client_no_nonce_without_csp
+    File.write(File.join(@dir, "rails-vite.json"), '{"url":"http://localhost:5173","sourceDir":"app/javascript"}')
+
+    html = vite_stylesheet_tag("app/javascript/admin.css")
+
+    assert_match %r{@vite/client}, html
+    refute_match %r{nonce=}, html
+  end
+
   # Proc asset host tests
 
   def test_vite_asset_path_with_proc_asset_host


### PR DESCRIPTION
Closes #25. Two parts — a code fix and a small helper — plus docs.

## 1. Nonce footgun (code fix)

In development, the `@vite/client` script and the React Fast Refresh preamble are emitted **once**, on the first `vite_*` call. They carried whatever nonce *that first call* passed — so a nonce-less first call (e.g. a `vite_stylesheet_tag`, since CSS links don't need a nonce) shipped a **nonce-less** `@vite/client`, which is blocked under [`strict-dynamic`](https://content-security-policy.com/strict-dynamic/).

These two gem-internal tags now fall back to the per-request nonce via `content_security_policy_nonce` when no explicit nonce is passed, matching how Rails' own asset helpers and vite_ruby resolve nonces — per request, not by call order. `respond_to?`-guarded, so controller-less renders and no-CSP apps keep their current behavior. Explicit `nonce:` still wins. Only the internal tags change; your own entry tags still take an explicit `nonce:`.

## 2. `RailsVite.dev_server_csp_source` (helper)

Apps running a restrictive CSP **in development** (Rails ships it disabled by default) must allow the Vite dev server's origin or the browser blocks it. This is awkward because:

- The dev server **port isn't fixed** — Vite walks to a free one if the default is taken, and only the running server knows which it bound (the plugin writes the real URL to the meta file at runtime). A hardcoded origin or static config (vite_ruby's approach) can be wrong.
- The URL is **unknown at boot**, when the `content_security_policy` block runs once — so a plain `RailsVite.config.dev_server_url` string would bake in `nil` and **raise at startup**.

`dev_server_csp_source` returns a per-request lambda that resolves to the real URL at request time (correct port), transforms `http`→`ws` / `https`→`wss` for the HMR socket, and contributes nothing when the server is down:

```ruby
if Rails.env.development?
  policy.script_src(*policy.script_src, RailsVite.dev_server_csp_source)
  policy.style_src(*policy.style_src, RailsVite.dev_server_csp_source)
  policy.connect_src(*policy.connect_src, RailsVite.dev_server_csp_source(websocket: true))
end
```

It qualifies `RailsVite.config` deliberately: Rails resolves CSP `Proc` sources via `context.instance_exec(&source)`, which rebinds `self` to the controller — and real controllers respond to `#config`, so a naive `-> { config.dev_server_url }` would hit `controller#config` and raise in production.

## Tests

- `tag_helper_test.rb` — nonce fix: nonce-less first call picks up the request nonce (client + react-refresh), explicit nonce wins, no-CSP renders without a nonce.
- `dev_server_csp_source_test.rb` — unit (http/ws/wss, nil when down) **plus a real `ActionDispatch::ContentSecurityPolicy#build`** with a context whose own `#config` raises (as a real controller's would), proving per-request resolution against `RailsVite`, not the rebound `self`. Mutation-checked: reverting to a bare `config` makes that test error, so it genuinely discriminates.

Full suite green (104 runs, 0 failures), `standardrb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)