### PR TITLE
Document Propshaft RAILS_ASSET_URL migration (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,16 @@ Then reference them in views:
 <%= vite_image_tag "app/assets/images/logo.png", alt: "Logo" %>
 ```
 
-**Migrating from Propshaft?** Vite resolves asset references itself, so you don't need Propshaft's `RAILS_ASSET_URL(...)` — reference assets natively and Vite fingerprints them:
+**Migrating from Propshaft?** Vite resolves asset references itself, so you don't need Propshaft's `RAILS_ASSET_URL(...)` — swap the logical path for a path relative to the referencing file, and Vite fingerprints it:
 
-- In CSS: `background: url(../assets/images/logo.svg)` — resolved and hashed at build.
+```css
+/* Propshaft */
+background: url(RAILS_ASSET_URL("logo.svg"));
+/* Vite */
+background: url(../assets/images/logo.svg);
+```
+
+- In CSS: works for any stylesheet Vite processes — an entry point, or imported from one.
 - In JS: `import logoUrl from '../assets/images/logo.svg'` (or pull in a whole folder with `import.meta.glob`).
 - In views: `vite_asset_path` / `vite_image_tag`, which read the Vite manifest.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Then reference them in views:
 <%= vite_image_tag "app/assets/images/logo.png", alt: "Logo" %>
 ```
 
+**Migrating from Propshaft?** Vite resolves asset references itself, so you don't need Propshaft's `RAILS_ASSET_URL(...)` — reference assets natively and Vite fingerprints them:
+
+- In CSS: `background: url(../assets/images/logo.svg)` — resolved and hashed at build.
+- In JS: `import logoUrl from '../assets/images/logo.svg'` (or pull in a whole folder with `import.meta.glob`).
+- In views: `vite_asset_path` / `vite_image_tag`, which read the Vite manifest.
+
 ## Vite Config
 
 The install generator creates a minimal `vite.config.ts`:


### PR DESCRIPTION
Closes #26.

Propshaft users rely on `RAILS_ASSET_URL(...)` to reference digested assets from CSS/JS. Vite resolves asset references natively, so that macro isn't needed — but a migrant won't know that without a pointer. Adds a short note to the "Asset Discovery" section covering the mapping:

- CSS `url(...)` → Vite resolves + fingerprints
- JS `import` / `import.meta.glob`
- view-side `vite_asset_path` / `vite_image_tag`

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)