### PR TITLE
Run the package.json build script on precompile, set type: module on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## Unreleased
+
+### Added
+
+- The install generator sets `"type": "module"` in package.json — Vite and rails-vite-plugin are ESM-only, and without it Node fails to load `vite.config.ts` under npm/pnpm/yarn. When package.json pins another `type`, the generator emits `vite.config.mts` instead ([@skryukov])
+
+### Changed
+
+- `vite:build` (and therefore `assets:precompile`) runs the package.json `build` script when one exists, so `"build": "vite build && vite build --ssr"` produces both client and SSR bundles on deploy. Apps without a `build` script keep the bare `vite build`. Test builds and auto-builds always use the bare command, since their extra flags (`--mode test`, `--logLevel warn`) would only reach the last command of a compound script ([@skryukov])
+
 ## rails_vite@0.2.3 / rails-vite-plugin@0.2.5 - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ npx vite build && npx vite build --ssr
 node ssr/ssr.js
 ```
 
+To build the SSR bundle during `assets:precompile`, define a `build` script — `vite:build` runs it when present:
+
+```json
+"scripts": {
+  "build": "vite build && vite build --ssr"
+}
+```
+
 ## Auto Build
 
 When the Vite dev server is not running, rails_vite automatically rebuilds assets on the first request if sources have changed. This is useful for system tests and quick checks without running `bin/dev`.
@@ -369,6 +377,8 @@ Defaults match the plugin defaults — no config needed if you follow convention
 | `rake vite:clobber` | Remove `public/vite/` |
 
 `vite:build` hooks into `assets:precompile` and `test:prepare` automatically. Skip with `SKIP_VITE_BUILD=1`.
+
+`vite:build` prefers your package.json `build` script when one exists (like jsbundling-rails), falling back to a bare `vite build`. Test builds always run `vite build --mode test` directly.
 
 
 ## jsbundling Mode

--- a/lib/generators/rails_vite/install/install_generator.rb
+++ b/lib/generators/rails_vite/install/install_generator.rb
@@ -10,8 +10,27 @@ module RailsVite
         run RailsVite::Tasks.add_command("vite", "rails-vite-plugin")
       end
 
+      # Vite and rails-vite-plugin are ESM-only: without `"type": "module"`,
+      # Node loads vite.config.ts via require and dies. Package managers
+      # create package.json on install but never set the field.
+      def ensure_esm_package
+        return unless File.exist?("package.json")
+
+        package_json = JSON.parse(File.read("package.json"))
+        return if package_json["type"] == "module"
+
+        if package_json.key?("type")
+          say %(package.json sets "type": "#{package_json["type"]}", but Vite and rails-vite-plugin are ESM-only — generating vite.config.mts instead.), :yellow
+        else
+          package_json["type"] = "module"
+          File.write("package.json", JSON.pretty_generate(package_json) + "\n")
+          say %(Added "type": "module" to package.json (Vite and rails-vite-plugin are ESM-only).)
+          warn_about_commonjs_configs
+        end
+      end
+
       def create_vite_config
-        template "vite.config.ts.tt", "vite.config.ts"
+        template "vite.config.ts.tt", esm_package? ? "vite.config.ts" : "vite.config.mts"
       end
 
       def create_entrypoint
@@ -64,6 +83,19 @@ module RailsVite
       end
 
       private
+
+      def esm_package?
+        File.exist?("package.json") && JSON.parse(File.read("package.json"))["type"] == "module"
+      rescue JSON::ParserError
+        false
+      end
+
+      def warn_about_commonjs_configs
+        commonjs_configs = Dir["*.config.js"].select { |f| File.read(f).match?(/\bmodule\.exports\b|\brequire\(/) }
+        return if commonjs_configs.empty?
+
+        say "These files use CommonJS and will break under \"type\": \"module\": #{commonjs_configs.join(", ")}. Rename them to .cjs.", :yellow
+      end
 
       def vite_dev_command
         RailsVite::Tasks.dev_command

--- a/lib/rails_vite/tasks.rb
+++ b/lib/rails_vite/tasks.rb
@@ -5,10 +5,10 @@ module RailsVite
     BUN_CMD = defined?(Bundlebun) ? Bundlebun::Runner.binstub_or_binary_path : "bun"
 
     COMMANDS = {
-      bun: {install: "#{BUN_CMD} install", add: "#{BUN_CMD} add -D", dev: "#{BUN_CMD} run vite", build: "#{BUN_CMD} run vite build"},
-      yarn: {install: "yarn install", add: "yarn add -D", dev: "yarn vite", build: "yarn vite build"},
-      pnpm: {install: "pnpm install", add: "pnpm add -D", dev: "pnpm vite", build: "pnpm vite build"},
-      npm: {install: "npm install", add: "npm install -D", dev: "npx vite", build: "npx vite build"}
+      bun: {install: "#{BUN_CMD} install", add: "#{BUN_CMD} add -D", dev: "#{BUN_CMD} run vite", build: "#{BUN_CMD} run vite build", run: "#{BUN_CMD} run"},
+      yarn: {install: "yarn install", add: "yarn add -D", dev: "yarn vite", build: "yarn vite build", run: "yarn run"},
+      pnpm: {install: "pnpm install", add: "pnpm add -D", dev: "pnpm vite", build: "pnpm vite build", run: "pnpm run"},
+      npm: {install: "npm install", add: "npm install -D", dev: "npx vite", build: "npx vite build", run: "npm run"}
     }.freeze
 
     LOCKFILES = {
@@ -36,11 +36,28 @@ module RailsVite
       cmd
     end
 
+    # The vite:build task prefers the app's package.json `build` script, so
+    # `"build": "vite build && vite build --ssr"` makes assets:precompile
+    # produce both bundles. Test builds and auto-builds keep the bare vite
+    # command: they append flags (`--mode test`, `--logLevel warn`) that
+    # would only reach the last command of a compound script.
+    def precompile_command
+      return build_command if Rails.env.test? || !package_json_build_script?
+      "#{command_for(:run)} build"
+    end
+
     def tool
       tool_determined_by_lockfile || tool_determined_by_executable
     end
 
     private
+
+    def package_json_build_script?
+      return false unless File.exist?("package.json")
+      !JSON.parse(File.read("package.json")).dig("scripts", "build").to_s.empty?
+    rescue JSON::ParserError
+      false
+    end
 
     def command_for(key)
       COMMANDS.dig(tool, key) ||

--- a/lib/tasks/rails_vite/build.rake
+++ b/lib/tasks/rails_vite/build.rake
@@ -7,7 +7,7 @@ namespace :vite do
 
   desc "Build Vite assets for production"
   task :build do
-    command = RailsVite::Tasks.build_command
+    command = RailsVite::Tasks.precompile_command
     system(command) || raise("rails_vite: Command build failed, ensure `#{command}` runs without errors")
   end
 

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+require "generators/rails_vite/install/install_generator"
+
+class InstallGeneratorEsmTest < Minitest::Test
+  def setup
+    @original_dir = Dir.pwd
+    @dir = Dir.mktmpdir
+    Dir.chdir(@dir)
+    @generator = RailsVite::Generators::InstallGenerator.new
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@dir)
+  end
+
+  def test_adds_type_module_when_missing
+    File.write("package.json", JSON.pretty_generate({"devDependencies" => {"vite" => "^8.0.0"}}))
+
+    capture_io { @generator.ensure_esm_package }
+
+    parsed = JSON.parse(File.read("package.json"))
+    assert_equal "module", parsed["type"]
+    assert_equal({"vite" => "^8.0.0"}, parsed["devDependencies"])
+  end
+
+  def test_keeps_package_json_untouched_when_already_esm
+    File.write("package.json", %({"type":"module"}))
+
+    capture_io { @generator.ensure_esm_package }
+
+    assert_equal %({"type":"module"}), File.read("package.json")
+  end
+
+  def test_leaves_explicit_commonjs_alone_and_warns
+    File.write("package.json", %({"type":"commonjs"}))
+
+    out, _err = capture_io { @generator.ensure_esm_package }
+
+    assert_equal "commonjs", JSON.parse(File.read("package.json"))["type"]
+    assert_match(/ESM-only/, out)
+  end
+
+  def test_skips_when_package_json_is_missing
+    capture_io { @generator.ensure_esm_package }
+
+    refute File.exist?("package.json")
+  end
+
+  def test_warns_about_commonjs_config_files
+    File.write("package.json", "{}")
+    File.write("postcss.config.js", "module.exports = {}\n")
+
+    out, _err = capture_io { @generator.ensure_esm_package }
+
+    assert_match(/postcss\.config\.js/, out)
+  end
+
+  def test_does_not_warn_about_esm_config_files
+    File.write("package.json", "{}")
+    File.write("postcss.config.js", "export default {}\n")
+
+    out, _err = capture_io { @generator.ensure_esm_package }
+
+    refute_match(/postcss\.config\.js/, out)
+  end
+end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -78,4 +78,66 @@ class TasksTest < Minitest::Test
     assert_equal "pnpm vite", RailsVite::Tasks.dev_command
     assert_equal "pnpm vite build", RailsVite::Tasks.build_command
   end
+
+  def test_precompile_command_prefers_package_json_build_script
+    FileUtils.touch("package-lock.json")
+    write_package_json(scripts: {build: "vite build && vite build --ssr"})
+    assert_equal "npm run build", RailsVite::Tasks.precompile_command
+  end
+
+  def test_precompile_command_run_forms_per_package_manager
+    write_package_json(scripts: {build: "vite build"})
+
+    {"yarn.lock" => "yarn run build",
+     "pnpm-lock.yaml" => "pnpm run build",
+     "bun.lock" => "bun run build"}.each do |lockfile, expected|
+      FileUtils.touch(lockfile)
+      assert_equal expected, RailsVite::Tasks.precompile_command
+      FileUtils.rm(lockfile)
+    end
+  end
+
+  def test_precompile_command_falls_back_without_build_script
+    FileUtils.touch("package-lock.json")
+    write_package_json(scripts: {dev: "vite"})
+    assert_equal "npx vite build", RailsVite::Tasks.precompile_command
+  end
+
+  def test_precompile_command_falls_back_without_package_json
+    FileUtils.touch("package-lock.json")
+    assert_equal "npx vite build", RailsVite::Tasks.precompile_command
+  end
+
+  def test_precompile_command_falls_back_on_empty_build_script
+    FileUtils.touch("package-lock.json")
+    write_package_json(scripts: {build: ""})
+    assert_equal "npx vite build", RailsVite::Tasks.precompile_command
+  end
+
+  def test_precompile_command_falls_back_on_malformed_package_json
+    FileUtils.touch("package-lock.json")
+    File.write("package.json", "{not json")
+    assert_equal "npx vite build", RailsVite::Tasks.precompile_command
+  end
+
+  def test_precompile_command_ignores_build_script_in_test_env
+    FileUtils.touch("package-lock.json")
+    write_package_json(scripts: {build: "vite build && vite build --ssr"})
+    Rails.stub(:env, ActiveSupport::StringInquirer.new("test")) do
+      assert_equal "npx vite build --mode test", RailsVite::Tasks.precompile_command
+    end
+  end
+
+  def test_build_command_appends_mode_test_in_test_env
+    FileUtils.touch("package-lock.json")
+    Rails.stub(:env, ActiveSupport::StringInquirer.new("test")) do
+      assert_equal "npx vite build --mode test", RailsVite::Tasks.build_command
+    end
+  end
+
+  private
+
+  def write_package_json(contents)
+    File.write("package.json", JSON.generate(contents))
+  end
 end


### PR DESCRIPTION
## What

Two DX fixes found while verifying SSR setups for the inertia-rails docs:

1. **`vite:build` prefers the package.json `build` script.** `assets:precompile` previously hardwired a bare `vite build`, so editing `scripts.build` had no effect and SSR users needed a rake-enhancement workaround to get their `ssr/` bundle built on deploy. With this change, `"build": "vite build && vite build --ssr"` drives the whole precompile, matching jsbundling-rails. Apps without a `build` script keep the exact previous behavior. Test builds and auto-builds always use the bare command: their appended flags (`--mode test`, `--logLevel warn`) would only reach the last command of a compound script.

2. **The install generator sets `"type": "module"` in package.json.** Vite and rails-vite-plugin are ESM-only; on npm/pnpm/yarn installs Node fails to load `vite.config.ts` with "this package is ESM only but it was tried to load by require" (bun masked this, which is why it slipped through). Package managers create package.json on install but never set the field. The generator now adds it, warns about CommonJS `*.config.js` files that would break, and emits `vite.config.mts` instead when package.json explicitly pins another `type`.

## Verification

- 118 gem tests (14 new), standardrb clean.
- Real-app acceptance for (1): an app with the compound build script and no workaround rake file produced both `public/vite/` and `ssr/ssr.js` from `RAILS_ENV=production bin/rails assets:precompile`; removing the script fell back to a client-only bare `vite build`.
- Real-app acceptance for (2): reproduced the ESM require failure on Node 22 + Vite 8.1.4 without the field, and confirmed the generator's exact mutation fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)