### PR TITLE
Ensure Vite commands are executed within Rails root

### DIFF
--- a/lib/rails_vite/auto_build.rb
+++ b/lib/rails_vite/auto_build.rb
@@ -26,7 +26,7 @@ module RailsVite
 
         # Build quietly: vite's per-build summary is noise on every auto-build
         # (e.g. each local system-test run). Warnings and errors still stream.
-        Rails.logger.error("rails-vite: build failed") unless system("#{RailsVite::Tasks.build_command} --logLevel warn")
+        Rails.logger.error("rails-vite: build failed") unless system("#{RailsVite::Tasks.build_command} --logLevel warn", chdir: Rails.root)
         @cached_source_mtime = nil
         @source_mtime_checked_at = nil
       end

--- a/lib/tasks/rails_vite/build.rake
+++ b/lib/tasks/rails_vite/build.rake
@@ -2,13 +2,13 @@ namespace :vite do
   desc "Install JavaScript dependencies"
   task :install do
     command = RailsVite::Tasks.install_command
-    system(command) || raise("rails_vite: Command install failed, ensure #{command.split.first} is installed")
+    system(command, chdir: Rails.root) || raise("rails_vite: Command install failed, ensure #{command.split.first} is installed")
   end
 
   desc "Build Vite assets for production"
   task :build do
     command = RailsVite::Tasks.build_command
-    system(command) || raise("rails_vite: Command build failed, ensure `#{command}` runs without errors")
+    system(command, chdir: Rails.root) || raise("rails_vite: Command build failed, ensure `#{command}` runs without errors")
   end
 
   Rake::Task["vite:build"].prereqs << :install unless ENV["SKIP_VITE_INSTALL"]

--- a/test/auto_build_test.rb
+++ b/test/auto_build_test.rb
@@ -36,7 +36,7 @@ class AutoBuildTest < Minitest::Test
     captured = nil
     with_root do
       RailsVite::Tasks.stub(:build_command, "vite build") do
-        RailsVite::AutoBuild.define_method(:system) do |cmd|
+        RailsVite::AutoBuild.define_method(:system) do |cmd, **|
           captured = cmd
           true
         end
@@ -139,7 +139,7 @@ class AutoBuildTest < Minitest::Test
 
   def stub_build(callback)
     RailsVite::Tasks.stub(:build_command, "true") do
-      RailsVite::AutoBuild.define_method(:system) do |cmd|
+      RailsVite::AutoBuild.define_method(:system) do |cmd, **|
         callback.call
         true
       end


### PR DESCRIPTION
I'm developing an Inertia integration for Rodauth, and have a dummy Rails app in my test directory. Since my Rails app is in a subdirectory of the working directory, auto-build was failing.

This ensures all commands run within Rails root, even when working directory is different. I updated `build.rake` for completeness, because Rake tasks can also be run from a subdirectory. For comparison, `vite_ruby` gem does the same.