### PR TITLE
Recursively collect CSS from imported chunks in resolve_css

### DIFF
--- a/lib/rails_vite/manifest.rb
+++ b/lib/rails_vite/manifest.rb
@@ -14,11 +14,14 @@ module RailsVite
       entry = manifest[name] || resolve_with_extension(name, manifest) ||
         raise(MissingEntryError.new(name, @path))
 
+      imports = resolve_imports(entry, Set.new, manifest)
+      imported_entries = imports.filter_map { |i| manifest.values.find { |e| e["file"] == i[:file] } }
+
       {
         file: entry["file"],
         integrity: entry["integrity"],
-        css: resolve_css(entry, manifest),
-        imports: resolve_imports(entry, Set.new, manifest)
+        css: resolve_css([entry] + imported_entries, manifest),
+        imports: imports
       }
     end
 
@@ -58,8 +61,8 @@ module RailsVite
       nil
     end
 
-    def resolve_css(entry, manifest)
-      entry.fetch("css", []).map do |css_file|
+    def resolve_css(entries, manifest)
+      entries.flat_map { |entry| entry.fetch("css", []) }.uniq.map do |css_file|
         integrity = manifest.values.find { |e| e["file"] == css_file }&.dig("integrity")
         {file: css_file, integrity: integrity}
       end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -43,6 +43,53 @@ class ManifestTest < Minitest::Test
     assert_includes result[:imports].map { |i| i[:file] }, "assets/vendor-b3c4d5e6.js"
   end
 
+  def test_lookup_collects_css_from_imported_chunks
+    manifest_data = {
+      "app/frontend/packs/feeds/show.ts" => {
+        "file" => "assets/show-abc123.js",
+        "isEntry" => true,
+        "css" => ["assets/show-def456.css"],
+        "imports" => ["_TemplateBase-xyz789.js"]
+      },
+      "_TemplateBase-xyz789.js" => {
+        "file" => "assets/TemplateBase-xyz789.js",
+        "css" => ["assets/TemplateBase-ghi000.css"]
+      }
+    }
+    File.write(@manifest_path, JSON.generate(manifest_data))
+    manifest = RailsVite::Manifest.new(@manifest_path)
+
+    result = manifest.lookup("app/frontend/packs/feeds/show.ts")
+    css_files = result[:css].map { |c| c[:file] }
+
+    assert_includes css_files, "assets/show-def456.css"
+    assert_includes css_files, "assets/TemplateBase-ghi000.css"
+  end
+
+  def test_lookup_dedupes_css_shared_across_imports
+    manifest_data = {
+      "entry.js" => {
+        "file" => "assets/entry.js",
+        "isEntry" => true,
+        "imports" => ["_a", "_b"]
+      },
+      "_a" => {
+        "file" => "assets/a.js",
+        "css" => ["assets/shared.css"]
+      },
+      "_b" => {
+        "file" => "assets/b.js",
+        "css" => ["assets/shared.css"]
+      }
+    }
+    File.write(@manifest_path, JSON.generate(manifest_data))
+    manifest = RailsVite::Manifest.new(@manifest_path)
+
+    result = manifest.lookup("entry.js")
+
+    assert_equal ["assets/shared.css"], result[:css].map { |c| c[:file] }
+  end
+
   def test_lookup_resolves_nested_imports
     result = @manifest.lookup("app/javascript/application.js")
     import_files = result[:imports].map { |i| i[:file] }


### PR DESCRIPTION
## Problem

`RailsVite::Manifest#resolve_css` only looks at the entry's own `css` field in the manifest. It doesn't recursively walk the entry's `imports` the way `resolve_imports` does for JS `modulepreload` tags.

As a result, when a shared component (e.g. a Vue SFC with `<style scoped>`) is imported by multiple entry points and gets split into its own chunk by Rollup, that chunk's CSS is never linked on the page — even though the JS chunk itself is correctly preloaded via `modulepreload`.

In a real app (Vue 3 + multiple Vite entries, one per page), this means any styling that lives in a shared/common component (layout wrapper, nav bar, etc.) silently disappears in production builds, while the same page renders correctly in dev mode (dev mode injects styles via HMR, not via the manifest, so the bug is invisible until you build for production).

### Reproduction

Given a manifest like:

```json
{
  "app/frontend/packs/feeds/show.ts": {
    "file": "assets/show-abc123.js",
    "isEntry": true,
    "css": ["assets/show-def456.css"],
    "imports": ["_TemplateBase-xyz789.js"]
  },
  "_TemplateBase-xyz789.js": {
    "file": "assets/TemplateBase-xyz789.js",
    "css": ["assets/TemplateBase-ghi000.css"]
  }
}
```

Calling `vite_typescript_tag("packs/feeds/show")` only emits a `<link rel="stylesheet">` for `show-def456.css`. `TemplateBase-ghi000.css` — which contains the shared layout component's scoped styles — is never linked, even though `TemplateBase-xyz789.js` correctly gets a `<link rel="modulepreload">`.

### Root cause

```ruby
# lib/rails_vite/manifest.rb (before)
def resolve_css(entry, manifest)
  entry.fetch("css", []).map do |css_file|
    integrity = manifest.values.find { |e| e["file"] == css_file }&.dig("integrity")
    {file: css_file, integrity: integrity}
  end
end
```

This doesn't look at `entry["imports"]` yet, unlike `resolve_imports`, which already recurses:

```ruby
def resolve_imports(entry, seen, manifest)
  entry.fetch("imports", []).flat_map do |import_key|
    next [] if seen.include?(import_key)
    seen.add(import_key)
    imported = manifest[import_key]
    next [] unless imported
    [{file: imported["file"], integrity: imported["integrity"]}] + resolve_imports(imported, seen, manifest)
  end
end
```

For reference, the predecessor gem [ElMassimo/vite_ruby](https://github.com/elmassimo/vite_ruby) already handled this by collecting CSS from both the entry and its resolved imports:

```ruby
# vite_ruby/lib/vite_ruby/manifest.rb
def resolve_entries(*names, **options)
  entries = names.map { |name| lookup!(name, **options) }
  imports = dev_server_running? ? [] : entries.flat_map { |entry| import_chunks_for(entry) }
  {
    scripts: entries.map { |entry| entry.fetch("file") },
    imports: imports.filter_map { |entry| entry.fetch("file") }.uniq,
    stylesheets: dev_server_running? ? [] : (entries + imports).flat_map { |entry| entry["css"] }.compact.uniq,
  }
end
```

https://github.com/ElMassimo/vite_ruby/blob/3edc67485fd4021072b43ad3a073ffa0fa851ede/vite_ruby/lib/vite_ruby/manifest.rb#L44-L54

So this looks like a small gap from re-implementing that behavior in this gem, rather than a design choice — happy to be corrected if there's a reason CSS was intentionally scoped to just the entry.

## Fix

`lookup` now resolves `imports` first, looks up the corresponding entry objects, and passes `[entry] + imported_entries` into `resolve_css`, which flattens+dedupes CSS across all of them:

```ruby
def lookup(name)
  manifest = data
  entry = manifest[name] || resolve_with_extension(name, manifest) ||
    raise(MissingEntryError.new(name, @path))

  imports = resolve_imports(entry, Set.new, manifest)
  imported_entries = imports.filter_map { |i| manifest.values.find { |e| e["file"] == i[:file] } }

  {
    file: entry["file"],
    integrity: entry["integrity"],
    css: resolve_css([entry] + imported_entries, manifest),
    imports: imports
  }
end

def resolve_css(entries, manifest)
  entries.flat_map { |entry| entry.fetch("css", []) }.uniq.map do |css_file|
    integrity = manifest.values.find { |e| e["file"] == css_file }&.dig("integrity")
    {file: css_file, integrity: integrity}
  end
end
```

`resolve_imports`'s existing `seen` set still guards against circular/duplicate imports when building `imported_entries`, so no separate cycle-detection logic was needed for the CSS path.

## Test plan
- [x] Added `test_lookup_collects_css_from_imported_chunks`, reproducing the `show.ts` / `_TemplateBase` scenario above
- [x] Added `test_lookup_dedupes_css_shared_across_imports`, covering CSS shared by multiple imported chunks (no duplicate `<link>` tags)
- [x] `bundle exec rake test` — 106 runs, 0 failures
- [x] `bundle exec rake standard` — clean
- [x] Confirmed CI passes on this branch in my fork
  - https://github.com/madogiwa0124/rails_vite/pull/1